### PR TITLE
Add Industrial CI for foxy and galactic

### DIFF
--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -3,7 +3,12 @@
 
 name: Industrial CI
 
-on: [push, pull_request]
+on: 
+  push:
+    branches: [ master ] 
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch: 
 
 jobs:
   industrial_ci:
@@ -12,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRO: [foxy]
+        ROS_DISTRO: [foxy, galactic]
         ROS_REPO: [testing]
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
@@ -24,7 +29,7 @@ jobs:
           key: ccache-${{ matrix.ROS_DISTRO }}-${{ matrix.ROS_REPO }}-${{github.run_id}}
           restore-keys: |
             ccache-${{ matrix.ROS_DISTRO }}-${{ matrix.ROS_REPO }}-
-      - uses: 'ros-industrial/industrial_ci@master' # run industrial_ci
+      - uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
           ROS_REPO: ${{ matrix.ROS_REPO }}

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -1,0 +1,30 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see README (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+name: Industrial CI
+
+on: [push, pull_request]
+
+jobs:
+  industrial_ci:
+    name: ROS ${{ matrix.ROS_DISTRO }} (${{ matrix.ROS_REPO }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [foxy]
+        ROS_REPO: [testing]
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ matrix.ROS_DISTRO }}-${{ matrix.ROS_REPO }}-${{github.run_id}}
+          restore-keys: |
+            ccache-${{ matrix.ROS_DISTRO }}-${{ matrix.ROS_REPO }}-
+      - uses: 'ros-industrial/industrial_ci@master' # run industrial_ci
+        env:
+          ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
+          ROS_REPO: ${{ matrix.ROS_REPO }}

--- a/canopen_core/CMakeLists.txt
+++ b/canopen_core/CMakeLists.txt
@@ -24,8 +24,6 @@ find_package(rclcpp_components REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(lifecycle_msgs REQUIRED)
 
 find_package(lely_core_libraries REQUIRED)
 find_package(canopen_interfaces REQUIRED)
@@ -37,8 +35,6 @@ set (dependencies
   rclcpp
   rclcpp_components
   yaml_cpp_vendor
-  rclcpp_lifecycle
-  lifecycle_msgs
   canopen_interfaces
 )
 

--- a/canopen_core/CMakeLists.txt
+++ b/canopen_core/CMakeLists.txt
@@ -24,6 +24,8 @@ find_package(rclcpp_components REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
 
 find_package(lely_core_libraries REQUIRED)
 find_package(canopen_interfaces REQUIRED)
@@ -35,6 +37,8 @@ set (dependencies
   rclcpp
   rclcpp_components
   yaml_cpp_vendor
+  rclcpp_lifecycle
+  lifecycle_msgs
   canopen_interfaces
 )
 

--- a/canopen_core/package.xml
+++ b/canopen_core/package.xml
@@ -14,7 +14,8 @@
   <depend>rclcpp_components</depend>
   <depend>yaml_cpp_vendor</depend>
   <depend>canopen_interfaces</depend>
-  
+  <depend>rclcpp_lifecycle</depend>
+  <depend>lifecycle_msgs</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
This pull request adds industrial_ci to the github Workflows. It runs for foxy and galactic.
#9 