### PR TITLE
Fix remote object bug

### DIFF
--- a/canopen_402_driver/include/canopen_402_driver/mc_device_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/mc_device_driver.hpp
@@ -52,6 +52,19 @@ namespace ros2_canopen
         std::shared_ptr<RemoteObject> create_remote_obj(uint16_t index, uint8_t subindex, CODataTypes type)
         {
             RemoteObject obj = {index, subindex, 0, type, false, false, true};
+            for(auto it = objs.begin(); it != objs.end(); ++it)
+            {
+                if(
+                    ((*it)->index == index)
+                    &&
+                    ((*it)->subindex == subindex)
+                    &&
+                    ((*it)->type == type)
+                )
+                {
+                    return *it;
+                }
+            }
             std::shared_ptr<RemoteObject> objp = std::make_shared<RemoteObject>(obj);
             objs.push_back(objp);
             return objp;


### PR DESCRIPTION
When calling service init on cia402 driver nodes, remote objects are created on every call not reused.
Solution implemented: Add check if remote object already exists to avoid multiple objects with same target.