### PR TITLE
fix ament_export_libraries

### DIFF
--- a/canopen_402_driver/CMakeLists.txt
+++ b/canopen_402_driver/CMakeLists.txt
@@ -118,7 +118,7 @@ ament_export_include_directories(
 )
 ament_export_libraries(
   canopen_402_driver
-  export_canopen_402_driver
+  lifecycle_canopen_402_driver
 )
 ament_export_targets(
   export_canopen_402_driver


### PR DESCRIPTION
I would recommend using [ament_cmake_auto](https://github.com/ament/ament_cmake/tree/rolling/ament_cmake_auto) to write CMakeLists files. This will greatly simplify CMakeLists files, normalize file directories, and avoid such typo. The downside is that there seems to be a lack of documentation right now, but it doesn't really require much documentation.
Here is a gist for reference:
https://gist.github.com/dirk-thomas/a76f952d05e7b21b0128