### PR TITLE
Publish joint state instead of velocity topics

### DIFF
--- a/canopen_402_driver/CMakeLists.txt
+++ b/canopen_402_driver/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(canopen_proxy_driver REQUIRED)
 find_package(Boost REQUIRED COMPONENTS container)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
+find_package(sensor_msgs)
 
 add_library(${PROJECT_NAME} 
   src/canopen_402_driver.cpp
@@ -38,6 +39,7 @@ ament_target_dependencies(
   "canopen_core"
   "canopen_proxy_driver"
   "canopen_base_driver"
+  "sensor_msgs"
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -71,6 +73,7 @@ ament_target_dependencies(
   "canopen_base_driver"
   "rclcpp_lifecycle"
   "lifecycle_msgs"
+  "sensor_msgs"
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,

--- a/canopen_402_driver/include/canopen_402_driver/lifecycle_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/lifecycle_canopen_402_driver.hpp
@@ -4,7 +4,7 @@
 
 #include "canopen_402_driver/visibility_control.h"
 #include "std_srvs/srv/trigger.hpp"
-#include "std_msgs/msg/float64.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
 #include "canopen_interfaces/srv/co_target_double.hpp"
 #include "canopen_proxy_driver/lifecycle_canopen_proxy_driver.hpp"
 #include "canopen_402_driver/motor.hpp"
@@ -35,8 +35,7 @@ namespace ros2_canopen
         rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_velocity_service;
         rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_position_service;
         rclcpp::Service<canopen_interfaces::srv::COTargetDouble>::SharedPtr handle_set_target_service;
-        rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr publish_actual_position;
-        rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr publish_actual_speed;
+        rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr publish_joint_state;
         uint32_t period_ms_;
         virtual bool add() override;
         virtual void register_ros_interface() override;

--- a/canopen_402_driver/package.xml
+++ b/canopen_402_driver/package.xml
@@ -15,6 +15,7 @@
   <depend>std_srvs</depend>
   <depend>canopen_proxy_driver</depend>
   <depend>boost</depend>
+  <depend>sensor_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/canopen_402_driver/src/lifecycle_canopen_402_driver.cpp
+++ b/canopen_402_driver/src/lifecycle_canopen_402_driver.cpp
@@ -117,16 +117,18 @@ void LifecycleMotionControllerDriver::handle_set_target(
 {
     if (activated_.load())
     {
-        response->success = motor_->setTarget(request->target);
+        double target = request->target * 1000;
+        response->success = motor_->setTarget(target);
     }
 }
 
 void LifecycleMotionControllerDriver::publish()
 {
     sensor_msgs::msg::JointState js_msg;
-    js_msg.name[0] = this->get_name();
-    js_msg.position[0] = mc_driver_->get_position();
-    js_msg.velocity[0] = mc_driver_->get_speed();
+    js_msg.name.push_back(this->get_name());
+    js_msg.position.push_back(mc_driver_->get_position()/1000);
+    js_msg.velocity.push_back(mc_driver_->get_speed()/1000);
+    js_msg.effort.push_back(0.0);
     publish_joint_state->publish(js_msg);
 }
 

--- a/canopen_402_driver/src/lifecycle_canopen_402_driver.cpp
+++ b/canopen_402_driver/src/lifecycle_canopen_402_driver.cpp
@@ -123,21 +123,18 @@ void LifecycleMotionControllerDriver::handle_set_target(
 
 void LifecycleMotionControllerDriver::publish()
 {
-    std_msgs::msg::Float64 pos_msg;
-    std_msgs::msg::Float64 speed_msg;
-    pos_msg.data = mc_driver_->get_position();
-    speed_msg.data = mc_driver_->get_speed();
-    publish_actual_position->publish(pos_msg);
-    publish_actual_speed->publish(speed_msg);
+    sensor_msgs::msg::JointState js_msg;
+    js_msg.name[0] = this->get_name();
+    js_msg.position[0] = mc_driver_->get_position();
+    js_msg.velocity[0] = mc_driver_->get_speed();
+    publish_joint_state->publish(pos_msg);
 }
 
 void LifecycleMotionControllerDriver::register_ros_interface()
 {
     RCLCPP_INFO(this->get_logger(), "register_ros_interface");
     LifecycleProxyDriver::register_ros_interface();
-    publish_actual_position = this->create_publisher<std_msgs::msg::Float64>("~/actual_position", 10);
-
-    publish_actual_speed = this->create_publisher<std_msgs::msg::Float64>("~/actual_speed", 10);
+    publish_joint_state = this->create_publisher<sensor_msgs::msg::JointState>("~/joint_state", 10);
     handle_init_service = this->create_service<std_srvs::srv::Trigger>(
         std::string(this->get_name()).append("/init").c_str(),
         std::bind(&LifecycleMotionControllerDriver::handle_init, this, _1, _2));

--- a/canopen_402_driver/src/lifecycle_canopen_402_driver.cpp
+++ b/canopen_402_driver/src/lifecycle_canopen_402_driver.cpp
@@ -127,7 +127,7 @@ void LifecycleMotionControllerDriver::publish()
     js_msg.name[0] = this->get_name();
     js_msg.position[0] = mc_driver_->get_position();
     js_msg.velocity[0] = mc_driver_->get_speed();
-    publish_joint_state->publish(pos_msg);
+    publish_joint_state->publish(js_msg);
 }
 
 void LifecycleMotionControllerDriver::register_ros_interface()

--- a/canopen_core/src/device_container_node.cpp
+++ b/canopen_core/src/device_container_node.cpp
@@ -254,5 +254,3 @@ void DeviceContainerNode::on_list_nodes(
     }
 }
 
-
->>>>>>> ec93cc5 (Remove artifacts)

--- a/canopen_core/src/device_container_node.cpp
+++ b/canopen_core/src/device_container_node.cpp
@@ -253,3 +253,6 @@ void DeviceContainerNode::on_list_nodes(
         response->full_node_names.push_back(it->second);
     }
 }
+
+
+>>>>>>> ec93cc5 (Remove artifacts)

--- a/canopen_core/src/device_container_node.cpp
+++ b/canopen_core/src/device_container_node.cpp
@@ -169,7 +169,7 @@ bool DeviceContainerNode::init_devices_from_config()
         RCLCPP_ERROR(this->get_logger(), "Error: Master not in configuration");
         return false;
     }
-
+    
     for (auto it = devices.begin(); it != devices.end(); it++)
     {
         if (it->find("master") == std::string::npos)
@@ -222,6 +222,23 @@ bool DeviceContainerNode::init()
   return true;
 }
 
+bool DeviceContainerNode::init(
+    const std::string& can_interface_name,
+    const std::string& master_config,
+    const std::string& bus_config,
+    const std::string& master_bin)
+{
+    can_interface_name_ = can_interface_name;
+    dcf_txt_ = master_config;
+    dcf_bin_ = master_bin;
+    bus_config_ = bus_config;
+
+    this->config_ = std::make_shared<ros2_canopen::ConfigurationManager>(bus_config_);
+    this->config_->init_config();
+    this->init_devices_from_config();
+    return true;
+}
+
 void DeviceContainerNode::on_list_nodes(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<ListNodes::Request> request,
@@ -236,4 +253,3 @@ void DeviceContainerNode::on_list_nodes(
         response->full_node_names.push_back(it->second);
     }
 }
-

--- a/canopen_mock_slave/include/canopen_mock_slave/cia402_slave.hpp
+++ b/canopen_mock_slave/include/canopen_mock_slave/cia402_slave.hpp
@@ -172,6 +172,10 @@ namespace ros2_canopen
                         std::this_thread::sleep_for(std::chrono::milliseconds(ccp_millis));
                         actual_position += increment;
                         (*this)[0x6064][0] = (int32_t)actual_position*1000;
+                        if(std::abs(actual_position - target_position) < 0.001)
+                        {
+                            RCLCPP_INFO(rclcpp::get_logger("cia402_slave"), "Reached Target %f", target_position);
+                        }
                     }
                 }
                 std::this_thread::sleep_for(std::chrono::milliseconds(ccp_millis));

--- a/canopen_tests/config/cia402_lifecycle/bus.yml
+++ b/canopen_tests/config/cia402_lifecycle/bus.yml
@@ -19,12 +19,14 @@ cia402_device_1:
   tpdo: # TPDO needed statusword, actual velocity, actual position, mode of operation
     1:
       enabled: true
+      cob_id: "auto"
       transmission: 0x01
       mapping:
         - {index: 0x6041, sub_index: 0} # status word
         - {index: 0x6061, sub_index: 0} # mode of operaiton display
     2:
       enabled: true
+      cob_id: "auto"
       transmission: 0x01
       mapping:
         - {index: 0x6064, sub_index: 0} # position actual value
@@ -36,11 +38,13 @@ cia402_device_1:
   rpdo: # RPDO needed controlword, target position, target velocity, mode of operation
     1:
       enabled: true
+      cob_id: "auto"
       mapping:
       - {index: 0x6040, sub_index: 0} # controlword
       - {index: 0x6060, sub_index: 0} # mode of operation
     2:
       enabled: true
+      cob_id: "auto"
       mapping:
       - {index: 0x607A, sub_index: 0} # target position
       - {index: 0x60FF, sub_index: 0} # target velocity

--- a/lely_core_libraries/CMakeLists.txt
+++ b/lely_core_libraries/CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 ExternalProject_Add(upstr_lely_core_libraries    # Name for custom target
   #--Download step--------------
   GIT_REPOSITORY https://gitlab.com/lely_industries/lely-core.git
-  GIT_TAG f13629b4fcc042744ff497c8bf7428cf2775aba8
+  GIT_TAG ac31cd5cdf2ded4b2a5ba4a94520f388450614ff
   TIMEOUT 60          
   #--Update/Patch step----------
   UPDATE_COMMAND touch <SOURCE_DIR>/config.h 


### PR DESCRIPTION
This will make canopen_402_devices publish joint_states.
It will also add an example for displaying robot based on joint_states.