### PR TITLE
Publish to joint_states, not joint_state

### DIFF
--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -64,7 +64,7 @@ template <>
 void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::init(bool called_from_base)
 {
 	NodeCanopenProxyDriver<rclcpp_lifecycle::LifecycleNode>::init(false);
-	publish_joint_state = this->node_->create_publisher<sensor_msgs::msg::JointState>("~/joint_state", 10);
+	publish_joint_state = this->node_->create_publisher<sensor_msgs::msg::JointState>("~/joint_states", 10);
 	handle_init_service = this->node_->create_service<std_srvs::srv::Trigger>(
 		std::string(this->node_->get_name()).append("/init").c_str(),
 		std::bind(&NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_init, this, _1, _2));


### PR DESCRIPTION
As per subject.

Even though this is a private topic, it would still seem like a good idea to use the conventional name (ie: `joint_states`).
