### PR TITLE
Better organize dependencies

### DIFF
--- a/canopen_402_driver/CMakeLists.txt
+++ b/canopen_402_driver/CMakeLists.txt
@@ -8,31 +8,26 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
+find_package(canopen_base_driver REQUIRED)
 find_package(canopen_core REQUIRED)
 find_package(canopen_interfaces REQUIRED)
-find_package(canopen_base_driver REQUIRED)
 find_package(canopen_proxy_driver REQUIRED)
-find_package(lely_core_libraries REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 
 set(dependencies
-  rclcpp
-  rclcpp_components
-  rclcpp_lifecycle
-  lifecycle_msgs
+  canopen_base_driver
   canopen_core
   canopen_interfaces
-  canopen_base_driver
   canopen_proxy_driver
-  lely_core_libraries
-  std_msgs
-  std_srvs
+  rclcpp
+  rclcpp_lifecycle
+  rclcpp_components
   sensor_msgs
+  std_srvs
 )
 
 add_library(lely_motion_controller_bridge
@@ -149,6 +144,9 @@ ament_export_libraries(
 )
 ament_export_targets(
   export_${PROJECT_NAME}
+)
+ament_export_dependencies(
+  ${dependencies}
 )
 
 ament_package()

--- a/canopen_402_driver/package.xml
+++ b/canopen_402_driver/package.xml
@@ -9,13 +9,16 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <depend>boost</depend>
+  <depend>canopen_base_driver</depend>
+  <depend>canopen_core</depend>
+  <depend>canopen_interfaces</depend>
+  <depend>canopen_proxy_driver</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>std_msgs</depend>
-  <depend>std_srvs</depend>
-  <depend>canopen_proxy_driver</depend>
-  <depend>boost</depend>
+  <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_srvs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/canopen_base_driver/CMakeLists.txt
+++ b/canopen_base_driver/CMakeLists.txt
@@ -8,23 +8,22 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
 find_package(canopen_core REQUIRED)
 find_package(canopen_interfaces REQUIRED)
 find_package(lely_core_libraries REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 
 set(dependencies
-  rclcpp
-  rclcpp_components
-  rclcpp_lifecycle
-  lifecycle_msgs
   canopen_core
   canopen_interfaces
   lely_core_libraries
+  rclcpp
+  rclcpp_components
+  rclcpp_lifecycle
   std_msgs
   std_srvs
 )
@@ -144,6 +143,9 @@ ament_export_libraries(
 )
 ament_export_targets(
   export_${PROJECT_NAME}
+)
+ament_export_dependencies(
+  ${dependencies}
 )
 
 ament_package()

--- a/canopen_base_driver/package.xml
+++ b/canopen_base_driver/package.xml
@@ -9,11 +9,14 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <depend>canopen_core</depend>
+  <depend>canopen_interfaces</depend>
+  <depend>lely_core_libraries</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>rclcpp_lifecycle</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>canopen_core</depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/canopen_core/CMakeLists.txt
+++ b/canopen_core/CMakeLists.txt
@@ -19,27 +19,22 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(canopen_interfaces REQUIRED)
+find_package(lely_core_libraries REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(lifecycle_msgs REQUIRED)
-find_package(lely_core_libraries REQUIRED)
-find_package(canopen_interfaces REQUIRED)
 
 set (dependencies
+  canopen_interfaces
   lely_core_libraries
+  lifecycle_msgs
   rclcpp
   rclcpp_components
-  yaml_cpp_vendor
   rclcpp_lifecycle
-  lifecycle_msgs
-  canopen_interfaces
-  rclcpp_components
+  yaml_cpp_vendor
 )
 
 
@@ -171,13 +166,7 @@ ament_export_targets(
 )
 
 ament_export_dependencies(
-  canopen_interfaces
-  lely_core_libraries
-  yaml_cpp_vendor
-  rclcpp
-  rclcpp_lifecycle
-  rclcpp_components
-  lifecycle_msgs
+  ${dependencies}
 )
 
 ament_package()

--- a/canopen_core/package.xml
+++ b/canopen_core/package.xml
@@ -9,13 +9,14 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>canopen_interfaces</depend>
   <depend>lely_core_libraries</depend>
+  <depend>lifecycle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>yaml_cpp_vendor</depend>
-  <depend>canopen_interfaces</depend>
   <depend>rclcpp_lifecycle</depend>
-  <depend>lifecycle_msgs</depend>
+  <depend>yaml_cpp_vendor</depend>
+
   <test_depend>ament_lint_auto</test_depend>
 
   <export>

--- a/canopen_fake_slaves/CMakeLists.txt
+++ b/canopen_fake_slaves/CMakeLists.txt
@@ -7,10 +7,17 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
 find_package(lely_core_libraries REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+
+set(dependencies
+  lely_core_libraries
+  lifecycle_msgs
+  rclcpp
+  rclcpp_lifecycle
+)
 
 add_executable(
   basic_slave_node
@@ -24,10 +31,7 @@ target_include_directories(basic_slave_node  PUBLIC
 
 ament_target_dependencies(
   basic_slave_node
-  "rclcpp"
-  "lely_core_libraries"
-  "rclcpp_lifecycle"
-  "lifecycle_msgs"
+  ${dependencies}
 )
 
 
@@ -43,10 +47,7 @@ target_include_directories(cia402_slave_node  PUBLIC
 
 ament_target_dependencies(
   cia402_slave_node
-  "rclcpp"
-  "lely_core_libraries"
-  "rclcpp_lifecycle"
-  "lifecycle_msgs"
+  ${dependencies}
 )
 
 
@@ -80,5 +81,9 @@ if(BUILD_TESTING)
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
+
+ament_export_dependencies(
+  ${dependencies}
+)
 
 ament_package()

--- a/canopen_fake_slaves/package.xml
+++ b/canopen_fake_slaves/package.xml
@@ -10,8 +10,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>lely_core_libraries</depend>
-  <depend>rclcpp_lifecycle</depend>
   <depend>lifecycle_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/canopen_master_driver/CMakeLists.txt
+++ b/canopen_master_driver/CMakeLists.txt
@@ -8,19 +8,20 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
 find_package(canopen_core REQUIRED)
 find_package(canopen_interfaces REQUIRED)
+find_package(lely_core_libraries REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 
 set(dependencies
+  canopen_core
+  canopen_interfaces
+  lely_core_libraries
   rclcpp
   rclcpp_components
   rclcpp_lifecycle
-  lifecycle_msgs
-  canopen_core
-  canopen_interfaces
 )
 
 add_library(lely_master_bridge
@@ -143,6 +144,10 @@ ament_export_libraries(
 
 ament_export_targets(
   export_${PROJECT_NAME}
+)
+
+ament_export_dependencies(
+  ${dependencies}
 )
 
 ament_package()

--- a/canopen_master_driver/package.xml
+++ b/canopen_master_driver/package.xml
@@ -11,6 +11,10 @@
 
   <depend>canopen_core</depend>
   <depend>canopen_interfaces</depend>
+  <depend>lely_core_libraries</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>rclcpp_lifecycle</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/canopen_proxy_driver/CMakeLists.txt
+++ b/canopen_proxy_driver/CMakeLists.txt
@@ -8,25 +8,22 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(rclcpp_components REQUIRED)
+find_package(canopen_base_driver REQUIRED)
 find_package(canopen_core REQUIRED)
 find_package(canopen_interfaces REQUIRED)
-find_package(canopen_base_driver REQUIRED)
-find_package(lely_core_libraries REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 
 set(dependencies
+  canopen_base_driver
+  canopen_core
+  canopen_interfaces
   rclcpp
   rclcpp_components
   rclcpp_lifecycle
-  lifecycle_msgs
-  canopen_core
-  canopen_interfaces
-  canopen_base_driver
-  lely_core_libraries
   std_msgs
   std_srvs
 )
@@ -126,6 +123,9 @@ ament_export_libraries(
 )
 ament_export_targets(
   export_${PROJECT_NAME}
+)
+ament_export_dependencies(
+  ${dependencies}
 )
 
 ament_package()

--- a/canopen_proxy_driver/package.xml
+++ b/canopen_proxy_driver/package.xml
@@ -9,11 +9,14 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <depend>canopen_base_driver</depend>
+  <depend>canopen_core</depend>
+  <depend>canopen_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>rclcpp_lifecycle</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>canopen_base_driver</depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/canopen_ros2_control/CMakeLists.txt
+++ b/canopen_ros2_control/CMakeLists.txt
@@ -7,16 +7,14 @@ endif()
 
 # find dependencies
 set(THIS_PACKAGE_INCLUDE_DEPENDS
-  canopen_core
-  canopen_base_driver
-  canopen_proxy_driver
   canopen_402_driver
+  canopen_core
+  canopen_proxy_driver
   hardware_interface
   pluginlib
+  rclcpp
   rclcpp_components
   rclcpp_lifecycle
-  std_srvs
-  sensor_msgs
 )
 
 find_package(ros2_control_test_assets)

--- a/canopen_ros2_control/package.xml
+++ b/canopen_ros2_control/package.xml
@@ -11,21 +11,26 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>canopen_402_driver</depend>
   <depend>canopen_core</depend>
   <depend>canopen_proxy_driver</depend>
-  <depend>canopen_402_driver</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp_lifecycle</depend>
-  <depend>std_srvs</depend>
 
   <exec_depend>xacro</exec_depend>
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>forward_command_controller</exec_depend>
 
   <exec_depend>canopen_fake_slaves</exec_depend>
   <exec_depend>canopen_tests</exec_depend>
+  <exec_depend>canopen_ros2_controllers</exec_depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ros2_control_test_assets</test_depend>

--- a/canopen_ros2_controllers/CMakeLists.txt
+++ b/canopen_ros2_controllers/CMakeLists.txt
@@ -3,19 +3,14 @@ project(canopen_ros2_controllers)
 
 # find dependencies
 set(THIS_PACKAGE_INCLUDE_DEPENDS
-  canopen_core
-  canopen_interfaces
-  canopen_base_driver
-  canopen_proxy_driver
   canopen_402_driver
-  lely_core_libraries
-  control_msgs
+  canopen_interfaces
+  canopen_proxy_driver
   controller_interface
   controller_manager
   hardware_interface
   pluginlib
   rclcpp
-  rclcpp_components
   rclcpp_lifecycle
   realtime_tools
   ros2_control_test_assets

--- a/canopen_ros2_controllers/package.xml
+++ b/canopen_ros2_controllers/package.xml
@@ -11,22 +11,21 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>rclcpp</depend>
-  <depend>rclcpp_lifecycle</depend>
-  <depend>hardware_interface</depend>
+  <depend>canopen_402_driver</depend>
+  <depend>canopen_interfaces</depend>
+  <depend>canopen_proxy_driver</depend>
   <depend>controller_interface</depend>
   <depend>controller_manager</depend>
-  <depend>realtime_tools</depend>
+  <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>realtime_tools</depend>
   <depend>ros2_control_test_assets</depend>
-  <depend>ament_cmake_gmock</depend>
-  <depend>canopen_core</depend>
-  <depend>canopen_proxy_driver</depend>
-  <depend>canopen_interfaces</depend>
-  <depend>canopen_402_driver</depend>
-  <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+
+  <test_depend>ament_cmake_gmock</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/canopen_tests/CMakeLists.txt
+++ b/canopen_tests/CMakeLists.txt
@@ -7,10 +7,6 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(canopen_core REQUIRED)
-find_package(canopen_interfaces REQUIRED)
-find_package(canopen_base_driver REQUIRED)
-find_package(canopen_proxy_driver REQUIRED)
 find_package(lely_core_libraries REQUIRED)
 
 

--- a/canopen_tests/package.xml
+++ b/canopen_tests/package.xml
@@ -8,15 +8,12 @@
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
   <build_depend>lely_core_libraries</build_depend>
-  <depend>canopen_core</depend>
-  <depend>canopen_interfaces</depend>
-  <depend>canopen_base_driver</depend>
-  <depend>canopen_proxy_driver</depend>
-  <depend>canopen_402_driver</depend>
-  <depend>rviz2</depend>
-  <depend>robot_state_publisher</depend>
-  <depend>joint_state_publisher</depend>
+
+  <exec_depend>canopen_402_driver</exec_depend>
+  <exec_depend>canopen_core</exec_depend>
+  <exec_depend>canopen_proxy_driver</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
 


### PR DESCRIPTION
This PR does a couple of things make the dependencies of each package better organized:
1. Add missing `ament_export_dependencies` so the downstream packages don't have to `find_package` all of the library dependencies.
2. `find_package` and link only packages that the given package #includes
3. Make sure that all of the packages that the library links against are specified in `<depend/>` tags in `package.xml`
4. Make sure that all of the packages that are used by the launch files are specified in `<exec_depend/>` tags in `package.xml`
5. Sort lists of dependencies in lexicographical order. 