### PR TITLE
Add Interpolated Position Mode (linear only, no PT or PVT)

### DIFF
--- a/canopen/sphinx/user-guide/cia402-driver.rst
+++ b/canopen/sphinx/user-guide/cia402-driver.rst
@@ -49,6 +49,9 @@ Services
   * - ~/cyclic_velocity_mode
     - Trigger
     - Switches to cyclic velocity mode
+  * - ~/interpolated_position_mode
+    - Trigger
+    - Switches to interpolated position mode, only linear mode with fixed time is supported
   * - ~/target
     - CODouble
     - Sets the target value. Only accepted when an operation mode is set.

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -32,6 +32,7 @@ protected:
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_velocity_service;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_velocity_service;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_position_service;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_interpolated_position_service;
   rclcpp::Service<canopen_interfaces::srv::COTargetDouble>::SharedPtr handle_set_target_service;
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr publish_joint_state;
   uint32_t period_ms_;
@@ -201,6 +202,20 @@ public:
    * @param [out] response
    */
   void handle_set_mode_cyclic_position(
+    const std_srvs::srv::Trigger::Request::SharedPtr request,
+    std_srvs::srv::Trigger::Response::SharedPtr response);
+
+  /**
+   * @brief Service Callback to set interpolated position mode
+   *
+   * Calls Motor402::enterModeAndWait with Interpolated Position Mode as
+   * Target Operation Mode. If successful, the motor was transitioned
+   * to Interpolated Position Mode. This only supports linear mode.
+   *
+   * @param [in] request
+   * @param [out] response
+   */
+  void handle_set_mode_interpolated_position(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
     std_srvs::srv::Trigger::Response::SharedPtr response);
 

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -55,6 +55,12 @@ void NodeCanopen402Driver<rclcpp::Node>::init(bool called_from_base)
     std::string(this->node_->get_name()).append("/cyclic_position_mode").c_str(),
     std::bind(&NodeCanopen402Driver<rclcpp::Node>::handle_set_mode_cyclic_position, this, _1, _2));
 
+  handle_set_mode_interpolated_position_service =
+    this->node_->create_service<std_srvs::srv::Trigger>(
+      std::string(this->node_->get_name()).append("/cyclic_position_mode").c_str(),
+      std::bind(
+        &NodeCanopen402Driver<rclcpp::Node>::handle_set_mode_interpolated_position, this, _1, _2));
+
   handle_set_mode_torque_service = this->node_->create_service<std_srvs::srv::Trigger>(
     std::string(this->node_->get_name()).append("/torque_mode").c_str(),
     std::bind(&NodeCanopen402Driver<rclcpp::Node>::handle_set_mode_torque, this, _1, _2));
@@ -106,6 +112,13 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::init(bool called_fro
     std::bind(
       &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_set_mode_cyclic_position, this,
       _1, _2));
+
+  handle_set_mode_interpolated_position_service = this->node_->create_service<
+    std_srvs::srv::Trigger>(
+    std::string(this->node_->get_name()).append("/cyclic_position_mode").c_str(),
+    std::bind(
+      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_set_mode_interpolated_position,
+      this, _1, _2));
 
   handle_set_mode_torque_service = this->node_->create_service<std_srvs::srv::Trigger>(
     std::string(this->node_->get_name()).append("/torque_mode").c_str(),
@@ -383,6 +396,23 @@ void NodeCanopen402Driver<NODETYPE>::handle_set_mode_cyclic_position(
     response->success = false;
   }
 }
+
+template <class NODETYPE>
+void NodeCanopen402Driver<NODETYPE>::handle_set_mode_interpolated_position(
+  const std_srvs::srv::Trigger::Request::SharedPtr request,
+  std_srvs::srv::Trigger::Response::SharedPtr response)
+{
+  if (this->activated_.load())
+  {
+    if (motor_->getMode() != MotorBase::Interpolated_Position)
+    {
+      response->success = motor_->enterModeAndWait(MotorBase::Interpolated_Position);
+      return;
+    }
+    response->success = false;
+  }
+}
+
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_set_mode_cyclic_velocity(
   const std_srvs::srv::Trigger::Request::SharedPtr request,

--- a/canopen_ros2_control/include/canopen_ros2_control/cia402_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/cia402_system.hpp
@@ -73,6 +73,7 @@ struct MotorNodeData
   MotorTriggerCommand cyclic_velocity_mode;
   MotorTriggerCommand cyclic_position_mode;
   MotorTriggerCommand torque_mode;
+  MotorTriggerCommand interpolated_position_mode;
 
   // setpoint
   MotorTarget target;

--- a/canopen_ros2_control/src/cia402_system.cpp
+++ b/canopen_ros2_control/src/cia402_system.cpp
@@ -212,6 +212,13 @@ std::vector<hardware_interface::CommandInterface> Cia402System::export_command_i
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, "cyclic_position_mode_fbk",
       &motor_data_[node_id].cyclic_position_mode.resp));
+    // set interpolated position mode
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      info_.joints[i].name, "interpolated_position_mode_cmd",
+      &motor_data_[node_id].interpolated_position_mode.ons_cmd));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      info_.joints[i].name, "interpolated_position_mode_fbk",
+      &motor_data_[node_id].interpolated_position_mode.resp));
   }
 
   return command_interfaces;
@@ -314,6 +321,8 @@ hardware_interface::return_type Cia402System::write(
       case MotorBase::Profiled_Torque:
         motion_controller_driver->set_target(motor_data_[it->first].target.torque_value);
         break;
+      case MotorBase::Interpolated_Position:
+        motion_controller_driver->set_target(motor_data_[it->first].target.position_value);
       default:
         RCLCPP_INFO(kLogger, "Mode not supported");
     }
@@ -347,6 +356,11 @@ void Cia402System::switchModes(uint id, const std::shared_ptr<ros2_canopen::Cia4
   if (motor_data_[id].torque_mode.is_commanded())
   {
     motor_data_[id].torque_mode.set_response(driver->set_mode_torque());
+  }
+
+  if (motor_data_[id].interpolated_position_mode.is_commanded())
+  {
+    motor_data_[id].interpolated_position_mode.set_response(driver->set_mode_torque());
   }
 }
 

--- a/canopen_ros2_controllers/include/canopen_ros2_controllers/cia402_device_controller.hpp
+++ b/canopen_ros2_controllers/include/canopen_ros2_controllers/cia402_device_controller.hpp
@@ -39,6 +39,8 @@ enum Cia402CommandInterfaces
   CYCLIC_VELOCITY_MODE_FBK,
   CYCLIC_POSITION_MODE_CMD,
   CYCLIC_POSITION_MODE_FBK,
+  INTERPOLATED_POSITION_MODE_CMD,
+  INTERPOLATED_POSITION_MODE_FBK,
 };
 
 enum Cia402StateInterfaces
@@ -122,6 +124,7 @@ protected:
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_velocity_service_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_velocity_service_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_position_service_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_interpolated_position_service_;
   rclcpp::Service<canopen_interfaces::srv::COTargetDouble>::SharedPtr handle_set_target_service_;
 };
 

--- a/canopen_ros2_controllers/src/cia402_device_controller.cpp
+++ b/canopen_ros2_controllers/src/cia402_device_controller.cpp
@@ -72,6 +72,10 @@ controller_interface::CallbackReturn Cia402DeviceController::on_init()
     "~/cyclic_position_mode", Cia402CommandInterfaces::CYCLIC_POSITION_MODE_CMD,
     Cia402CommandInterfaces::CYCLIC_POSITION_MODE_FBK);
 
+  handle_set_mode_interpolated_position_service_ = createTriggerSrv(
+    "~/interpolated_position_mode", Cia402CommandInterfaces::INTERPOLATED_POSITION_MODE_CMD,
+    Cia402CommandInterfaces::INTERPOLATED_POSITION_MODE_FBK);
+
   /*
   handle_set_mode_torque_service_ = createTriggerSrv("~/torque_mode",
                                                              Cia402CommandInterfaces::,
@@ -102,6 +106,8 @@ Cia402DeviceController::command_interface_configuration() const
   command_interfaces_config.names.push_back(joint_name_ + "/" + "cyclic_velocity_mode_fbk");
   command_interfaces_config.names.push_back(joint_name_ + "/" + "cyclic_position_mode_cmd");
   command_interfaces_config.names.push_back(joint_name_ + "/" + "cyclic_position_mode_fbk");
+  command_interfaces_config.names.push_back(joint_name_ + "/" + "interpolated_position_mode_cmd");
+  command_interfaces_config.names.push_back(joint_name_ + "/" + "interpolated_position_mode_fbk");
   return command_interfaces_config;
 }
 


### PR DESCRIPTION
This adds interpolated position mode. Linear only not PT or PVT.


Signed-off-by: Christoph Hellmann Santos <christoph.hellmann.santos@ipa.fraunhofer.de>