### PR TITLE
Proper scaling from the device

### DIFF
--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -53,9 +53,9 @@ public:
   virtual void deactivate(bool called_from_base) override;
   virtual void add_to_master() override;
 
-  virtual double get_speed() { return this->mc_driver_->get_speed() * scale_pos_from_dev_; }
+  virtual double get_speed() { return this->mc_driver_->get_speed() * scale_vel_from_dev_; }
 
-  virtual double get_position() { return this->mc_driver_->get_position() * scale_vel_from_dev_; }
+  virtual double get_position() { return this->mc_driver_->get_position() * scale_pos_from_dev_; }
 
   virtual uint16_t get_mode() { return motor_->getMode(); }
 


### PR DESCRIPTION
Fixed the scaling factor variable that was being used to calculate velocity and position data from the device. 