### PR TITLE
Fix stack smashing

### DIFF
--- a/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
@@ -338,7 +338,9 @@ public:
     else
     {
       booted.store(true);
+      return true;
     }
+    return false;
   }
 
   /**


### PR DESCRIPTION
Fix stack smashing caused by stack-protector in release builds.
This was the result of a no return statement issue.