### PR TITLE
Add device diagnostics messages

### DIFF
--- a/canopen_402_driver/include/canopen_402_driver/motor.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/motor.hpp
@@ -169,9 +169,8 @@ public:
   {
     this->enable_diagnostics_.store(enable);
     this->diagnostic_status_ = status;
-    this->diagnostic_status_->level = diagnostic_msgs::msg::DiagnosticStatus::OK;
     this->diagnostic_key_value_ = std::make_shared<diagnostic_msgs::msg::KeyValue>();
-    this->diagnostic_key_value_->key = "Motor402";
+    this->diagnostic_key_value_->key = "CiA402";
   }
 
 private:

--- a/canopen_402_driver/include/canopen_402_driver/motor.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/motor.hpp
@@ -10,13 +10,12 @@
 #include <limits>
 #include <mutex>
 #include <thread>
-#include "diagnostic_msgs/msg/diagnostic_status.hpp"
-#include "diagnostic_msgs/msg/key_value.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "canopen_402_driver/default_homing_mode.hpp"
 #include "canopen_402_driver/mode_forward_helper.hpp"
 #include "canopen_402_driver/profiled_position_mode.hpp"
+#include "canopen_base_driver/diagnostic_collector.hpp"
 #include "canopen_base_driver/lely_driver_bridge.hpp"
 
 namespace ros2_canopen
@@ -164,13 +163,10 @@ public:
     return (double)this->driver->universal_get_value<int32_t>(0x6064, 0);
   }
 
-  void set_diagnostic_status_msgs(
-    std::shared_ptr<diagnostic_msgs::msg::DiagnosticStatus> status, bool enable)
+  void set_diagnostic_status_msgs(std::shared_ptr<DiagnosticsCollector> status, bool enable)
   {
     this->enable_diagnostics_.store(enable);
-    this->diagnostic_status_ = status;
-    this->diagnostic_key_value_ = std::make_shared<diagnostic_msgs::msg::KeyValue>();
-    this->diagnostic_key_value_->key = "CiA402";
+    this->diag_collector_ = status;
   }
 
 private:
@@ -211,9 +207,8 @@ private:
   const uint16_t supported_drive_modes_index = 0x6502;
 
   // Diagnostic components
-  std::atomic<bool> enable_diagnostics_ = false;
-  std::shared_ptr<diagnostic_msgs::msg::DiagnosticStatus> diagnostic_status_;
-  std::shared_ptr<diagnostic_msgs::msg::KeyValue> diagnostic_key_value_;
+  std::atomic<bool> enable_diagnostics_;
+  std::shared_ptr<DiagnosticsCollector> diag_collector_;
 };
 
 }  // namespace ros2_canopen

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -42,6 +42,7 @@ protected:
 
   void publish();
   virtual void poll_timer_callback() override;
+  void diagnostic_timer_callback() override;
 
 public:
   NodeCanopen402Driver(NODETYPE * node);

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -42,7 +42,7 @@ protected:
 
   void publish();
   virtual void poll_timer_callback() override;
-  void diagnostic_timer_callback() override;
+  void diagnostic_callback(diagnostic_updater::DiagnosticStatusWrapper & stat) override;
 
 public:
   NodeCanopen402Driver(NODETYPE * node);

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -255,7 +255,7 @@ void NodeCanopen402Driver<NODETYPE>::activate(bool called_from_base)
 {
   NodeCanopenProxyDriver<NODETYPE>::activate(false);
   motor_->registerDefaultModes();
-  motor_->set_diagnostic_status_msgs(this->diagnostic_status_, this->diagnostic_enabled_);
+  motor_->set_diagnostic_status_msgs(this->diagnostic_collector_, this->diagnostic_enabled_);
 }
 
 template <class NODETYPE>
@@ -604,15 +604,17 @@ bool NodeCanopen402Driver<NODETYPE>::set_target(double target)
 }
 
 template <class NODETYPE>
-void NodeCanopen402Driver<NODETYPE>::diagnostic_timer_callback()
+void NodeCanopen402Driver<NODETYPE>::diagnostic_callback(
+  diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   this->motor_->handleDiag();
 
-  auto diag = diagnostic_msgs::msg::DiagnosticArray();
-  diag.header.stamp = this->node_->now();
-  diag.status.push_back(*this->diagnostic_status_);
-
-  this->diagnostic_publisher_->publish(diag);
+  stat.summary(this->diagnostic_collector_->getLevel(), this->diagnostic_collector_->getMessage());
+  stat.add("device_state", this->diagnostic_collector_->getValue("DEVICE"));
+  stat.add("nmt_state", this->diagnostic_collector_->getValue("NMT"));
+  stat.add("emcy_state", this->diagnostic_collector_->getValue("EMCY"));
+  stat.add("cia402_mode", this->diagnostic_collector_->getValue("cia402_mode"));
+  stat.add("cia402_state", this->diagnostic_collector_->getValue("cia402_state"));
 }
 
 #endif

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -255,6 +255,7 @@ void NodeCanopen402Driver<NODETYPE>::activate(bool called_from_base)
 {
   NodeCanopenProxyDriver<NODETYPE>::activate(false);
   motor_->registerDefaultModes();
+  motor_->set_diagnostic_status_msgs(this->diagnostic_status_, this->diagnostic_enabled_);
 }
 
 template <class NODETYPE>
@@ -600,6 +601,18 @@ bool NodeCanopen402Driver<NODETYPE>::set_target(double target)
   {
     return false;
   }
+}
+
+template <class NODETYPE>
+void NodeCanopen402Driver<NODETYPE>::diagnostic_timer_callback()
+{
+  this->motor_->handleDiag();
+
+  auto diag = diagnostic_msgs::msg::DiagnosticArray();
+  diag.header.stamp = this->node_->now();
+  diag.status.push_back(*this->diagnostic_status_);
+
+  this->diagnostic_publisher_->publish(diag);
 }
 
 #endif

--- a/canopen_402_driver/src/motor.cpp
+++ b/canopen_402_driver/src/motor.cpp
@@ -173,7 +173,7 @@ bool Motor402::switchState(const State402::InternalState & target)
     }
     else if (enable_diagnostics_.load() && success)
     {
-      this->diag_collector_->addf("cia402_state", "State transition: %d -> %d", state, next);
+      this->diag_collector_->addf("cia402_state", "State switched to: %d", next);
     }
     lock.unlock();
     if (state != next && !state_handler_.waitForNewState(abstime, state))

--- a/canopen_402_driver/src/motor.cpp
+++ b/canopen_402_driver/src/motor.cpp
@@ -72,8 +72,8 @@ bool Motor402::switchMode(uint16_t mode)
     }
     if (enable_diagnostics_.load())
     {
-      this->diagnostic_key_value_->value = "No mode selected: " + std::to_string(mode);
-      this->diagnostic_status_->values.push_back(*this->diagnostic_key_value_);
+      this->diagnostic_status_->values.push_back(
+        this->diagnostic_key_value_->set__value("No mode selected: " + std::to_string(mode)));
     }
     return true;
   }
@@ -137,8 +137,8 @@ bool Motor402::switchMode(uint16_t mode)
       okay = true;
       if (enable_diagnostics_.load())
       {
-        this->diagnostic_key_value_->value = "Mode selected: " + std::to_string(mode);
-        this->diagnostic_status_->values.push_back(*this->diagnostic_key_value_);
+        this->diagnostic_status_->values.push_back(
+          this->diagnostic_key_value_->set__value("Mode selected: " + std::to_string(mode)));
       }
     }
     else
@@ -147,8 +147,8 @@ bool Motor402::switchMode(uint16_t mode)
       driver->universal_set_value<int8_t>(op_mode_index, 0x0, mode_id_);
       if (enable_diagnostics_.load())
       {
-        this->diagnostic_key_value_->value = "Mode switch timed out: " + std::to_string(mode);
-        this->diagnostic_status_->values.push_back(*this->diagnostic_key_value_);
+        this->diagnostic_status_->values.push_back(this->diagnostic_key_value_->set__value(
+          "Mode switch timed out: " + std::to_string(mode)));
       }
     }
   }
@@ -174,11 +174,10 @@ bool Motor402::switchState(const State402::InternalState & target)
       RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Could not set transition.");
       return false;
     }
-    else if (enable_diagnostics_.load())
+    else if (enable_diagnostics_.load() && success)
     {
-      this->diagnostic_key_value_->value =
-        "Transition: " + std::to_string(state) + " -> " + std::to_string(next);
-      this->diagnostic_status_->values.push_back(*this->diagnostic_key_value_);
+      this->diagnostic_status_->values.push_back(this->diagnostic_key_value_->set__value(
+        "State transition: " + std::to_string(state) + " -> " + std::to_string(next)));
     }
     lock.unlock();
     if (state != next && !state_handler_.waitForNewState(abstime, state))
@@ -186,9 +185,8 @@ bool Motor402::switchState(const State402::InternalState & target)
       RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Transition timed out.");
       if (enable_diagnostics_.load())
       {
-        this->diagnostic_key_value_->value =
-          "Transition timed out: " + std::to_string(state) + " -> " + std::to_string(next);
-        this->diagnostic_status_->values.push_back(*this->diagnostic_key_value_);
+        this->diagnostic_status_->values.push_back(this->diagnostic_key_value_->set__value(
+          "State transition timed out: " + std::to_string(state) + " -> " + std::to_string(next)));
       }
       return false;
     }

--- a/canopen_base_driver/CMakeLists.txt
+++ b/canopen_base_driver/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
 
 set(dependencies
   canopen_core
@@ -26,6 +27,7 @@ set(dependencies
   rclcpp_lifecycle
   std_msgs
   std_srvs
+  diagnostic_msgs
 )
 
 

--- a/canopen_base_driver/CMakeLists.txt
+++ b/canopen_base_driver/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(diagnostic_msgs REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 
 set(dependencies
   canopen_core
@@ -27,7 +27,7 @@ set(dependencies
   rclcpp_lifecycle
   std_msgs
   std_srvs
-  diagnostic_msgs
+  diagnostic_updater
 )
 
 

--- a/canopen_base_driver/include/canopen_base_driver/diagnostic_collector.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/diagnostic_collector.hpp
@@ -1,112 +1,102 @@
 #ifndef DIAGNOSTICS_COLLECTOR_HPP_
 #define DIAGNOSTICS_COLLECTOR_HPP_
 
-#include <string>
-#include <unordered_map>
 #include <atomic>
 #include <mutex>
+#include <string>
+#include <unordered_map>
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
 #include "diagnostic_updater/diagnostic_updater.hpp"
 #include "diagnostic_updater/publisher.hpp"
 
 namespace ros2_canopen
 {
-    class DiagnosticsCollector
-    {
-    public:
+class DiagnosticsCollector
+{
+public:
+  DiagnosticsCollector() : level_(diagnostic_msgs::msg::DiagnosticStatus::OK) {}
 
-        DiagnosticsCollector() : level_(diagnostic_msgs::msg::DiagnosticStatus::OK)
-        {
-        }
+  unsigned char getLevel() const
+  {
+    return static_cast<unsigned char>(level_.load(std::memory_order_relaxed));
+  }
 
-        unsigned char getLevel() const
-        {
-            return static_cast<unsigned char>(level_.load(std::memory_order_relaxed));
-        }
+  std::string getMessage() const { return message_; }
 
-        std::string getMessage() const
-        {
-            return message_;
-        }
+  std::string getValue(const std::string & key) const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = values_.find(key);
+    if (it != values_.end())
+      return it->second;
+    else
+      return "";  // Return an empty string if key not found
+  }
 
-        std::string getValue(const std::string& key) const
-        {
-            std::lock_guard<std::mutex> lock(mutex_);
-            auto it = values_.find(key);
-            if (it != values_.end())
-                return it->second;
-            else
-                return "";  // Return an empty string if key not found
-        }
+  void summary(unsigned char lvl, const std::string & message)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    this->setLevel(lvl);
+    this->setMessage(message);
+  }
 
-        void summary(unsigned char lvl, const std::string& message)
-        {
-            std::lock_guard<std::mutex> lock(mutex_);
-            this->setLevel(lvl);
-            this->setMessage(message);
-        }
+  void summayf(unsigned char lvl, const char * format, ...)
+  {
+    va_list args;
+    va_start(args, format);
+    char buffer[1024];
+    vsnprintf(buffer, sizeof(buffer), format, args);
+    va_end(args);
+    summary(lvl, std::string(buffer));
+  }
 
-        void summayf(unsigned char lvl, const char* format, ...)
-        {
-            va_list args;
-            va_start(args, format);
-            char buffer[1024];
-            vsnprintf(buffer, sizeof(buffer), format, args);
-            va_end(args);
-            summary(lvl, std::string(buffer));
-        }
+  void add(const std::string & key, const std::string & value)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    this->setValue(key, value);
+  }
 
-        void add(const std::string& key, const std::string& value)
-        {
-            std::lock_guard<std::mutex> lock(mutex_);
-            this->setValue(key, value);
-        }
+  void addf(const std::string & key, const char * format, ...)
+  {
+    va_list args;
+    va_start(args, format);
+    char buffer[1024];
+    vsnprintf(buffer, sizeof(buffer), format, args);
+    va_end(args);
+    add(key, std::string(buffer));
+  }
 
-        void addf(const std::string& key, const char* format, ...)
-        {
-            va_list args;
-            va_start(args, format);
-            char buffer[1024];
-            vsnprintf(buffer, sizeof(buffer), format, args);
-            va_end(args);
-            add(key, std::string(buffer));
-        }
+  void updateAll(
+    unsigned char lvl, const std::string & message, const std::string & key,
+    const std::string & value)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    this->setLevel(lvl);
+    this->setMessage(message);
+    this->setValue(key, value);
+  }
 
-        void updateAll(unsigned char lvl, const std::string& message, const std::string& key, const std::string& value)
-        {
-            std::lock_guard<std::mutex> lock(mutex_);
-            this->setLevel(lvl);
-            this->setMessage(message);
-            this->setValue(key, value);
-        }
+private:
+  std::atomic<unsigned char> level_;
+  std::string message_;
+  std::unordered_map<std::string, std::string> values_;
+  mutable std::mutex mutex_;
 
-    private:
-        std::atomic<unsigned char> level_;
-        std::string message_;
-        std::unordered_map<std::string, std::string> values_;
-        mutable std::mutex mutex_;
+  void setLevel(unsigned char lvl)
+  {
+    level_.store(static_cast<unsigned char>(lvl), std::memory_order_relaxed);
+  }
 
-        void setLevel(unsigned char lvl)
-        {
-            level_.store(static_cast<unsigned char>(lvl), std::memory_order_relaxed);
-        }
+  void setMessage(const std::string & message) { message_ = message; }
 
-        void setMessage(const std::string& message)
-        {
-            message_ = message;
-        }
+  void setValue(const std::string & key, const std::string & value) { values_[key] = value; }
 
-        void setValue(const std::string& key, const std::string& value)
-        {
-            values_[key] = value;
-        }
-
-        // std::unordered_map<std::string, std::string> getValues() const
-        // {
-        //     std::lock_guard<std::mutex> lock(mutex_);
-        //     return values_;
-        // }
-    };
+  // std::unordered_map<std::string, std::string> getValues() const
+  // {
+  //     std::lock_guard<std::mutex> lock(mutex_);
+  //     return values_;
+  // }
+};
 }  // namespace ros2_canopen
 
 #endif  // DIAGNOSTICS_COLLECTOR_HPP_

--- a/canopen_base_driver/include/canopen_base_driver/diagnostic_collector.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/diagnostic_collector.hpp
@@ -1,0 +1,112 @@
+#ifndef DIAGNOSTICS_COLLECTOR_HPP_
+#define DIAGNOSTICS_COLLECTOR_HPP_
+
+#include <string>
+#include <unordered_map>
+#include <atomic>
+#include <mutex>
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+#include "diagnostic_updater/diagnostic_updater.hpp"
+#include "diagnostic_updater/publisher.hpp"
+
+namespace ros2_canopen
+{
+    class DiagnosticsCollector
+    {
+    public:
+
+        DiagnosticsCollector() : level_(diagnostic_msgs::msg::DiagnosticStatus::OK)
+        {
+        }
+
+        unsigned char getLevel() const
+        {
+            return static_cast<unsigned char>(level_.load(std::memory_order_relaxed));
+        }
+
+        std::string getMessage() const
+        {
+            return message_;
+        }
+
+        std::string getValue(const std::string& key) const
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = values_.find(key);
+            if (it != values_.end())
+                return it->second;
+            else
+                return "";  // Return an empty string if key not found
+        }
+
+        void summary(unsigned char lvl, const std::string& message)
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            this->setLevel(lvl);
+            this->setMessage(message);
+        }
+
+        void summayf(unsigned char lvl, const char* format, ...)
+        {
+            va_list args;
+            va_start(args, format);
+            char buffer[1024];
+            vsnprintf(buffer, sizeof(buffer), format, args);
+            va_end(args);
+            summary(lvl, std::string(buffer));
+        }
+
+        void add(const std::string& key, const std::string& value)
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            this->setValue(key, value);
+        }
+
+        void addf(const std::string& key, const char* format, ...)
+        {
+            va_list args;
+            va_start(args, format);
+            char buffer[1024];
+            vsnprintf(buffer, sizeof(buffer), format, args);
+            va_end(args);
+            add(key, std::string(buffer));
+        }
+
+        void updateAll(unsigned char lvl, const std::string& message, const std::string& key, const std::string& value)
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            this->setLevel(lvl);
+            this->setMessage(message);
+            this->setValue(key, value);
+        }
+
+    private:
+        std::atomic<unsigned char> level_;
+        std::string message_;
+        std::unordered_map<std::string, std::string> values_;
+        mutable std::mutex mutex_;
+
+        void setLevel(unsigned char lvl)
+        {
+            level_.store(static_cast<unsigned char>(lvl), std::memory_order_relaxed);
+        }
+
+        void setMessage(const std::string& message)
+        {
+            message_ = message;
+        }
+
+        void setValue(const std::string& key, const std::string& value)
+        {
+            values_[key] = value;
+        }
+
+        // std::unordered_map<std::string, std::string> getValues() const
+        // {
+        //     std::lock_guard<std::mutex> lock(mutex_);
+        //     return values_;
+        // }
+    };
+}  // namespace ros2_canopen
+
+#endif  // DIAGNOSTICS_COLLECTOR_HPP_

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
@@ -3,9 +3,7 @@
 
 #include "canopen_base_driver/lely_driver_bridge.hpp"
 #include "canopen_core/node_interfaces/node_canopen_driver.hpp"
-#include "diagnostic_msgs/msg/diagnostic_array.hpp"
-#include "diagnostic_msgs/msg/diagnostic_status.hpp"
-#include "diagnostic_msgs/msg/key_value.hpp"
+#include "canopen_base_driver/diagnostic_collector.hpp"
 #include "std_msgs/msg/string.hpp"
 #include "std_srvs/srv/trigger.hpp"
 
@@ -48,10 +46,8 @@ protected:
   // Diagnostic components
   std::atomic<bool> diagnostic_enabled_;
   uint32_t diagnostic_period_ms_;
-  rclcpp::TimerBase::SharedPtr diagnostic_timer_;
-  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostic_publisher_;
-  std::shared_ptr<diagnostic_msgs::msg::KeyValue> diagnostic_key_value_;
-  std::shared_ptr<diagnostic_msgs::msg::DiagnosticStatus> diagnostic_status_;
+  std::shared_ptr<diagnostic_updater::Updater> diagnostic_updater_;
+  std::shared_ptr<DiagnosticsCollector> diagnostic_collector_;
 
   virtual void poll_timer_callback();
   void nmt_listener();
@@ -60,7 +56,7 @@ protected:
   virtual void on_rpdo(COData data);
   void emcy_listener();
   virtual void on_emcy(COEmcy emcy);
-  virtual void diagnostic_timer_callback();
+  virtual void diagnostic_callback(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
 public:
   NodeCanopenBaseDriver(NODETYPE * node);

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
@@ -47,6 +47,7 @@ protected:
 
   // Diagnostic components
   std::atomic<bool> diagnostic_enabled_;
+  uint32_t diagnostic_period_ms_;
   rclcpp::TimerBase::SharedPtr diagnostic_timer_;
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostic_publisher_;
   std::shared_ptr<diagnostic_msgs::msg::KeyValue> diagnostic_key_value_;

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
@@ -3,6 +3,9 @@
 
 #include "canopen_base_driver/lely_driver_bridge.hpp"
 #include "canopen_core/node_interfaces/node_canopen_driver.hpp"
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+#include "diagnostic_msgs/msg/key_value.hpp"
 #include "std_msgs/msg/string.hpp"
 #include "std_srvs/srv/trigger.hpp"
 
@@ -41,6 +44,14 @@ protected:
   std::shared_ptr<ros2_canopen::SafeQueue<ros2_canopen::COEmcy>> emcy_queue_;
   std::shared_ptr<ros2_canopen::SafeQueue<ros2_canopen::COData>> rpdo_queue_;
   rclcpp::TimerBase::SharedPtr poll_timer_;
+
+  // Diagnostic components
+  std::atomic<bool> diagnostic_enabled_;
+  rclcpp::TimerBase::SharedPtr diagnostic_timer_;
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostic_publisher_;
+  std::shared_ptr<diagnostic_msgs::msg::KeyValue> diagnostic_key_value_;
+  std::shared_ptr<diagnostic_msgs::msg::DiagnosticStatus> diagnostic_status_;
+
   virtual void poll_timer_callback();
   void nmt_listener();
   virtual void on_nmt(canopen::NmtState nmt_state);
@@ -48,6 +59,7 @@ protected:
   virtual void on_rpdo(COData data);
   void emcy_listener();
   virtual void on_emcy(COEmcy emcy);
+  virtual void diagnostic_timer_callback();
 
 public:
   NodeCanopenBaseDriver(NODETYPE * node);

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
@@ -1,9 +1,9 @@
 #ifndef NODE_CANOPEN_BASE_DRIVER
 #define NODE_CANOPEN_BASE_DRIVER
 
+#include "canopen_base_driver/diagnostic_collector.hpp"
 #include "canopen_base_driver/lely_driver_bridge.hpp"
 #include "canopen_core/node_interfaces/node_canopen_driver.hpp"
-#include "canopen_base_driver/diagnostic_collector.hpp"
 #include "std_msgs/msg/string.hpp"
 #include "std_srvs/srv/trigger.hpp"
 

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -300,7 +300,7 @@ void NodeCanopenBaseDriver<NODETYPE>::on_rpdo(COData data)
 template <class NODETYPE>
 void NodeCanopenBaseDriver<NODETYPE>::on_emcy(COEmcy emcy)
 {
-  diagnostic_collector_->summayf(
+  diagnostic_collector_->summary(
     diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Emergency message received");
   std::string emcy_msg = "Emergency message: ";
   emcy_msg.append("eec: ");

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -45,10 +45,31 @@ void NodeCanopenBaseDriver<rclcpp_lifecycle::LifecycleNode>::configure(bool call
   }
 
   // Diagnostic components
-  // diagnostic_enabled_ = this->config_["diagnostic"]["enabled"].as<bool>();
-  diagnostic_enabled_ = true;
+  try
+  {
+    diagnostic_enabled_ = this->config_["diagnostics"]["enable"].as<bool>();
+  }
+  catch (...)
+  {
+    RCLCPP_ERROR(
+      this->node_->get_logger(),
+      "Could not read enable diagnostics from config, setting to false.");
+    diagnostic_enabled_ = false;
+  }
   if (diagnostic_enabled_.load())
   {
+    try
+    {
+      diagnostic_period_ms_ = this->config_["diagnostics"]["period"].as<std::uint32_t>();
+    }
+    catch (...)
+    {
+      RCLCPP_ERROR(
+        this->node_->get_logger(),
+        "Could not read diagnostics period from config, setting to 1000ms");
+      diagnostic_period_ms_ = 1000;
+    }
+
     diagnostic_status_->name = this->node_->get_name();
     diagnostic_status_->hardware_id = std::to_string(this->node_id_);
     diagnostic_publisher_ = this->node_->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
@@ -81,10 +102,31 @@ void NodeCanopenBaseDriver<rclcpp::Node>::configure(bool called_from_base)
   }
 
   // Diagnostic components
-  // diagnostic_enabled_ = this->config_["diagnostic"]["enabled"].as<bool>();
-  diagnostic_enabled_ = true;
+  try
+  {
+    diagnostic_enabled_ = this->config_["diagnostics"]["enable"].as<bool>();
+  }
+  catch (...)
+  {
+    RCLCPP_ERROR(
+      this->node_->get_logger(),
+      "Could not read enable diagnostics from config, setting to false.");
+    diagnostic_enabled_ = false;
+  }
   if (diagnostic_enabled_.load())
   {
+    try
+    {
+      diagnostic_period_ms_ = this->config_["diagnostics"]["period"].as<std::uint32_t>();
+    }
+    catch (...)
+    {
+      RCLCPP_ERROR(
+        this->node_->get_logger(),
+        "Could not read diagnostics period from config, setting to 1000ms");
+      diagnostic_period_ms_ = 1000;
+    }
+
     diagnostic_status_->name = this->node_->get_name();
     diagnostic_status_->hardware_id = std::to_string(this->node_id_);
     diagnostic_publisher_ = this->node_->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
@@ -120,8 +162,9 @@ void NodeCanopenBaseDriver<NODETYPE>::activate(bool called_from_base)
 
   if (diagnostic_enabled_.load())
   {
+    RCLCPP_INFO(this->node_->get_logger(), "Starting with diagnostics enabled.");
     diagnostic_timer_ = this->node_->create_wall_timer(
-      std::chrono::milliseconds(1000),
+      std::chrono::milliseconds(diagnostic_period_ms_),
       std::bind(&NodeCanopenBaseDriver<NODETYPE>::diagnostic_timer_callback, this),
       this->timer_cbg_);
   }

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -158,7 +158,8 @@ void NodeCanopenBaseDriver<NODETYPE>::activate(bool called_from_base)
   if (diagnostic_enabled_.load())
   {
     RCLCPP_INFO(this->node_->get_logger(), "Starting with diagnostics enabled.");
-    diagnostic_updater_->add("diagnostic updater", this, &NodeCanopenBaseDriver<NODETYPE>::diagnostic_callback);
+    diagnostic_updater_->add(
+      "diagnostic updater", this, &NodeCanopenBaseDriver<NODETYPE>::diagnostic_callback);
   }
 }
 
@@ -227,7 +228,8 @@ void NodeCanopenBaseDriver<NODETYPE>::add_to_master()
 
   if (diagnostic_enabled_.load())
   {
-    diagnostic_collector_->updateAll(diagnostic_msgs::msg::DiagnosticStatus::OK, "Device ready", "DEVICE", "Added to master.");
+    diagnostic_collector_->updateAll(
+      diagnostic_msgs::msg::DiagnosticStatus::OK, "Device ready", "DEVICE", "Added to master.");
   }
 }
 
@@ -251,7 +253,9 @@ void NodeCanopenBaseDriver<NODETYPE>::remove_from_master()
   }
   if (diagnostic_enabled_.load())
   {
-    diagnostic_collector_->updateAll(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Device removed", "DEVICE", "Removed from master.");
+    diagnostic_collector_->updateAll(
+      diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Device removed", "DEVICE",
+      "Removed from master.");
   }
 }
 template <class NODETYPE>
@@ -296,7 +300,8 @@ void NodeCanopenBaseDriver<NODETYPE>::on_rpdo(COData data)
 template <class NODETYPE>
 void NodeCanopenBaseDriver<NODETYPE>::on_emcy(COEmcy emcy)
 {
-  diagnostic_collector_->summayf(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Emergency message received");
+  diagnostic_collector_->summayf(
+    diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Emergency message received");
   std::string emcy_msg = "Emergency message: ";
   emcy_msg.append("eec: ");
   emcy_msg.append(std::to_string(emcy.eec));
@@ -414,7 +419,8 @@ void NodeCanopenBaseDriver<NODETYPE>::emcy_listener()
 }
 
 template <class NODETYPE>
-void NodeCanopenBaseDriver<NODETYPE>::diagnostic_callback(diagnostic_updater::DiagnosticStatusWrapper & stat)
+void NodeCanopenBaseDriver<NODETYPE>::diagnostic_callback(
+  diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
 }
 

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -189,11 +189,10 @@ void NodeCanopenBaseDriver<NODETYPE>::add_to_master()
 
   if (diagnostic_enabled_.load())
   {
-    diagnostic_key_value_->key = "Add to master";
-    diagnostic_key_value_->value = "OK";
     diagnostic_status_->level = diagnostic_msgs::msg::DiagnosticStatus::STALE;
     diagnostic_status_->message = "Device booted.";
-    diagnostic_status_->values.push_back(*diagnostic_key_value_);
+    diagnostic_status_->values.push_back(
+      diagnostic_key_value_->set__key("Add to master").set__value("OK"));
   }
 }
 
@@ -217,11 +216,10 @@ void NodeCanopenBaseDriver<NODETYPE>::remove_from_master()
   }
   if (diagnostic_enabled_.load())
   {
-    diagnostic_key_value_->key = "Remove to master";
-    diagnostic_key_value_->value = "OK";
     diagnostic_status_->level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
     diagnostic_status_->message = "Device removed from the master.";
-    diagnostic_status_->values.push_back(*diagnostic_key_value_);
+    diagnostic_status_->values.push_back(
+      diagnostic_key_value_->set__key("Remove to master").set__value("OK"));
   }
 }
 template <class NODETYPE>
@@ -268,7 +266,6 @@ void NodeCanopenBaseDriver<NODETYPE>::on_emcy(COEmcy emcy)
 {
   diagnostic_status_->level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
   diagnostic_status_->message = "Emergency message received.";
-  diagnostic_key_value_->key = "EMCY";
   std::string emcy_msg = "Emergency message received. ";
   emcy_msg.append("eec: ");
   emcy_msg.append(std::to_string(emcy.eec));
@@ -280,8 +277,8 @@ void NodeCanopenBaseDriver<NODETYPE>::on_emcy(COEmcy emcy)
     emcy_msg.append(std::to_string(msef));
     emcy_msg.append(" ");
   }
-  diagnostic_key_value_->value = emcy_msg;
-  diagnostic_status_->values.push_back(*diagnostic_key_value_);
+  diagnostic_status_->values.push_back(
+    diagnostic_key_value_->set__key("EMCY").set__value(emcy_msg));
 }
 
 template <class NODETYPE>

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -70,10 +70,10 @@ void NodeCanopenBaseDriver<rclcpp_lifecycle::LifecycleNode>::configure(bool call
       diagnostic_period_ms_ = 1000;
     }
 
-    diagnostic_status_->name = this->node_->get_name();
+    diagnostic_status_->name = "/" + std::string(this->node_->get_name());
     diagnostic_status_->hardware_id = std::to_string(this->node_id_);
-    diagnostic_publisher_ = this->node_->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
-      std::string(this->node_->get_name()).append("/diagnostic"), 10);
+    diagnostic_publisher_ =
+      this->node_->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10);
   }
 }
 template <>
@@ -127,10 +127,10 @@ void NodeCanopenBaseDriver<rclcpp::Node>::configure(bool called_from_base)
       diagnostic_period_ms_ = 1000;
     }
 
-    diagnostic_status_->name = this->node_->get_name();
+    diagnostic_status_->name = "/" + std::string(this->node_->get_name());
     diagnostic_status_->hardware_id = std::to_string(this->node_id_);
-    diagnostic_publisher_ = this->node_->create_publisher<diagnostic_msgs::msg::DiagnosticArray>(
-      std::string(this->node_->get_name()).append("/diagnostic"), 10);
+    diagnostic_publisher_ =
+      this->node_->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10);
   }
 }
 

--- a/canopen_base_driver/package.xml
+++ b/canopen_base_driver/package.xml
@@ -18,6 +18,7 @@
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>boost</depend>
+  <depend>diagnostic_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/canopen_base_driver/package.xml
+++ b/canopen_base_driver/package.xml
@@ -18,7 +18,7 @@
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>boost</depend>
-  <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver.hpp
+++ b/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver.hpp
@@ -29,6 +29,7 @@ protected:
   virtual void on_nmt(canopen::NmtState nmt_state) override;
   virtual void on_rpdo(COData data) override;
   virtual void on_tpdo(const canopen_interfaces::msg::COData::SharedPtr msg);
+  virtual void diagnostic_timer_callback() override;
 
   void on_nmt_state_reset(
     const std_srvs::srv::Trigger::Request::SharedPtr request,

--- a/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver.hpp
+++ b/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver.hpp
@@ -29,7 +29,7 @@ protected:
   virtual void on_nmt(canopen::NmtState nmt_state) override;
   virtual void on_rpdo(COData data) override;
   virtual void on_tpdo(const canopen_interfaces::msg::COData::SharedPtr msg);
-  virtual void diagnostic_timer_callback() override;
+  virtual void diagnostic_callback(diagnostic_updater::DiagnosticStatusWrapper & stat) override;
 
   void on_nmt_state_reset(
     const std_srvs::srv::Trigger::Request::SharedPtr request,

--- a/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver_impl.hpp
+++ b/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver_impl.hpp
@@ -109,56 +109,62 @@ void NodeCanopenProxyDriver<NODETYPE>::on_nmt(canopen::NmtState nmt_state)
       case canopen::NmtState::BOOTUP:
         message.data = "BOOTUP";
         this->diagnostic_status_->message = "Device is booting up.";
-        this->diagnostic_key_value_->value = "BOOTUP";
+        this->diagnostic_status_->values.push_back(
+          this->diagnostic_key_value_->set__value("BOOTUP"));
         break;
       case canopen::NmtState::PREOP:
         message.data = "PREOP";
         this->diagnostic_status_->level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
         this->diagnostic_status_->message = "Device is in pre-operational state.";
-        this->diagnostic_key_value_->value = "PREOP";
+        this->diagnostic_status_->values.push_back(
+          this->diagnostic_key_value_->set__value("PREOP"));
         break;
       case canopen::NmtState::RESET_COMM:
         message.data = "RESET_COMM";
         this->diagnostic_status_->level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
         this->diagnostic_status_->message = "Device is in reset communication state.";
-        this->diagnostic_key_value_->value = "RESET_COMM";
+        this->diagnostic_status_->values.push_back(
+          this->diagnostic_key_value_->set__value("RESET_COMM"));
         break;
       case canopen::NmtState::RESET_NODE:
         message.data = "RESET_NODE";
         this->diagnostic_status_->level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
         this->diagnostic_status_->message = "Device is in reset node state.";
-        this->diagnostic_key_value_->value = "RESET_NODE";
+        this->diagnostic_status_->values.push_back(
+          this->diagnostic_key_value_->set__value("RESET_NODE"));
         break;
       case canopen::NmtState::START:
         message.data = "START";
         this->diagnostic_status_->message = "Device is in operational state.";
-        this->diagnostic_key_value_->value = "START";
+        this->diagnostic_status_->values.push_back(
+          this->diagnostic_key_value_->set__value("START"));
         break;
       case canopen::NmtState::STOP:
         message.data = "STOP";
         this->diagnostic_status_->level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
         this->diagnostic_status_->message = "Device is in stopped state.";
-        this->diagnostic_key_value_->value = "STOP";
+        this->diagnostic_status_->values.push_back(this->diagnostic_key_value_->set__value("STOP"));
         break;
       case canopen::NmtState::TOGGLE:
         message.data = "TOGGLE";
         this->diagnostic_status_->level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
         this->diagnostic_status_->message = "Device is in toggle state.";
-        this->diagnostic_key_value_->value = "TOGGLE";
+        this->diagnostic_status_->values.push_back(
+          this->diagnostic_key_value_->set__value("TOGGLE"));
         break;
       default:
         RCLCPP_ERROR(this->node_->get_logger(), "Unknown NMT State.");
         message.data = "ERROR";
         this->diagnostic_status_->level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
         this->diagnostic_status_->message = "Unknown NMT State.";
-        this->diagnostic_key_value_->value = "ERROR";
+        this->diagnostic_status_->values.push_back(
+          this->diagnostic_key_value_->set__value("ERROR"));
         break;
     }
     RCLCPP_INFO(
       this->node_->get_logger(), "Slave %hhu: Switched NMT state to %s",
       this->lely_driver_->get_id(), message.data.c_str());
 
-    this->diagnostic_status_->values.push_back(*this->diagnostic_key_value_);
     nmt_state_publisher->publish(message);
   }
 }

--- a/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver_impl.hpp
+++ b/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver_impl.hpp
@@ -105,36 +105,44 @@ void NodeCanopenProxyDriver<NODETYPE>::on_nmt(canopen::NmtState nmt_state)
     {
       case canopen::NmtState::BOOTUP:
         message.data = "BOOTUP";
-        this->diagnostic_collector_->updateAll(diagnostic_msgs::msg::DiagnosticStatus::OK, "NMT bootup", "NMT", "BOOTUP");
+        this->diagnostic_collector_->updateAll(
+          diagnostic_msgs::msg::DiagnosticStatus::OK, "NMT bootup", "NMT", "BOOTUP");
         break;
       case canopen::NmtState::PREOP:
         message.data = "PREOP";
-        this->diagnostic_collector_->updateAll(diagnostic_msgs::msg::DiagnosticStatus::OK, "NMT preop", "NMT", "PREOP");
+        this->diagnostic_collector_->updateAll(
+          diagnostic_msgs::msg::DiagnosticStatus::OK, "NMT preop", "NMT", "PREOP");
         break;
       case canopen::NmtState::RESET_COMM:
         message.data = "RESET_COMM";
-        this->diagnostic_collector_->updateAll(diagnostic_msgs::msg::DiagnosticStatus::WARN, "NMT reset comm", "NMT", "RESET_COMM");
+        this->diagnostic_collector_->updateAll(
+          diagnostic_msgs::msg::DiagnosticStatus::WARN, "NMT reset comm", "NMT", "RESET_COMM");
         break;
       case canopen::NmtState::RESET_NODE:
         message.data = "RESET_NODE";
-        this->diagnostic_collector_->updateAll(diagnostic_msgs::msg::DiagnosticStatus::WARN, "NMT reset node", "NMT", "RESET_NODE");
+        this->diagnostic_collector_->updateAll(
+          diagnostic_msgs::msg::DiagnosticStatus::WARN, "NMT reset node", "NMT", "RESET_NODE");
         break;
       case canopen::NmtState::START:
         message.data = "START";
-        this->diagnostic_collector_->updateAll(diagnostic_msgs::msg::DiagnosticStatus::OK, "NMT start", "NMT", "START");
+        this->diagnostic_collector_->updateAll(
+          diagnostic_msgs::msg::DiagnosticStatus::OK, "NMT start", "NMT", "START");
         break;
       case canopen::NmtState::STOP:
         message.data = "STOP";
-        this->diagnostic_collector_->updateAll(diagnostic_msgs::msg::DiagnosticStatus::OK, "NMT stop", "NMT", "STOP");
+        this->diagnostic_collector_->updateAll(
+          diagnostic_msgs::msg::DiagnosticStatus::OK, "NMT stop", "NMT", "STOP");
         break;
       case canopen::NmtState::TOGGLE:
         message.data = "TOGGLE";
-        this->diagnostic_collector_->updateAll(diagnostic_msgs::msg::DiagnosticStatus::OK, "NMT toggle", "NMT", "TOGGLE");
+        this->diagnostic_collector_->updateAll(
+          diagnostic_msgs::msg::DiagnosticStatus::OK, "NMT toggle", "NMT", "TOGGLE");
         break;
       default:
         RCLCPP_ERROR(this->node_->get_logger(), "Unknown NMT State.");
         message.data = "ERROR";
-        this->diagnostic_collector_->updateAll(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "NMT unknown state", "NMT", "ERROR");
+        this->diagnostic_collector_->updateAll(
+          diagnostic_msgs::msg::DiagnosticStatus::ERROR, "NMT unknown state", "NMT", "ERROR");
         break;
     }
     RCLCPP_INFO(
@@ -312,7 +320,8 @@ bool NodeCanopenProxyDriver<NODETYPE>::sdo_write(ros2_canopen::COData & data)
 }
 
 template <class NODETYPE>
-void NodeCanopenProxyDriver<NODETYPE>::diagnostic_callback(diagnostic_updater::DiagnosticStatusWrapper & stat)
+void NodeCanopenProxyDriver<NODETYPE>::diagnostic_callback(
+  diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   stat.summary(this->diagnostic_collector_->getLevel(), this->diagnostic_collector_->getMessage());
   stat.add("device_state", this->diagnostic_collector_->getValue("DEVICE"));

--- a/canopen_tests/CMakeLists.txt
+++ b/canopen_tests/CMakeLists.txt
@@ -13,7 +13,9 @@ find_package(lely_core_libraries REQUIRED)
 generate_dcf(simple)
 cogen_dcf(cia402)
 generate_dcf(cia402_lifecycle)
+cogen_dcf(cia402_diagnostics)
 generate_dcf(simple_lifecycle)
+cogen_dcf(simple_diagnostics)
 generate_dcf(robot_control)
 
 install(DIRECTORY

--- a/canopen_tests/config/cia402_diagnostics/bus.yml
+++ b/canopen_tests/config/cia402_diagnostics/bus.yml
@@ -1,0 +1,62 @@
+options:
+  dcf_path: "@BUS_CONFIG_PATH@"
+
+master:
+  node_id: 1
+  driver: "ros2_canopen::MasterDriver"
+  package: "canopen_master_driver"
+  sync_period: 10000
+
+defaults:
+  dcf: "cia402_slave.eds"
+  driver: "ros2_canopen::Cia402Driver"
+  package: "canopen_402_driver"
+  diagnostics:
+    enable: true
+    period: 1000 # in milliseconds
+  revision_number: 0
+  sdo:
+    - {index: 0x60C2, sub_index: 1, value: 50} # Set interpolation time for cyclic modes to 50 ms
+    - {index: 0x60C2, sub_index: 2, value: -3} # Set base 10-3s
+    - {index: 0x6081, sub_index: 0, value: 1000}
+    - {index: 0x6083, sub_index: 0, value: 2000}
+  tpdo: # TPDO needed statusword, actual velocity, actual position, mode of operation
+    1:
+      enabled: true
+      cob_id: "auto"
+      transmission: 0x01
+      mapping:
+        - {index: 0x6041, sub_index: 0} # status word
+        - {index: 0x6061, sub_index: 0} # mode of operation display
+    2:
+      enabled: true
+      cob_id: "auto"
+      transmission: 0x01
+      mapping:
+        - {index: 0x6064, sub_index: 0} # position actual value
+        - {index: 0x606c, sub_index: 0} # velocity actual position
+    3:
+      enabled: false
+    4:
+      enabled: false
+  rpdo: # RPDO needed controlword, target position, target velocity, mode of operation
+    1:
+      enabled: true
+      cob_id: "auto"
+      mapping:
+      - {index: 0x6040, sub_index: 0} # controlword
+      - {index: 0x6060, sub_index: 0} # mode of operation
+    2:
+      enabled: true
+      cob_id: "auto"
+      mapping:
+      - {index: 0x607A, sub_index: 0} # target position
+      - {index: 0x60FF, sub_index: 0} # target velocity
+
+nodes:
+  cia402_device_1:
+    node_id: 2
+  cia402_device_2:
+    node_id: 3
+  cia402_device_3:
+    node_id: 4

--- a/canopen_tests/config/cia402_diagnostics/cia402_slave.eds
+++ b/canopen_tests/config/cia402_diagnostics/cia402_slave.eds
@@ -1,0 +1,1441 @@
+[DeviceInfo]
+VendorName=ROS-Industrial
+VendorNumber=0x555
+ProductName=CIA402VTD
+BaudRate_10=0
+BaudRate_20=1
+BaudRate_50=1
+BaudRate_125=1
+BaudRate_250=1
+BaudRate_500=1
+BaudRate_800=1
+BaudRate_1000=1
+DynamicChannelsSupported=0
+GroupMessaging=0
+LSS_Supported=0
+Granularity=8
+SimpleBootUpSlave=1
+SimpleBootUpMaster=0
+NrOfRXPDO=4
+NrOfTXPDO=4
+
+[Comments]
+Lines=0
+
+[DummyUsage]
+Dummy0001=0
+Dummy0002=0
+Dummy0003=0
+Dummy0004=0
+Dummy0005=0
+Dummy0006=0
+Dummy0007=0
+
+[MandatoryObjects]
+SupportedObjects=3
+1=0x1000
+2=0x1001
+3=0x1018
+
+[ManufacturerObjects]
+SupportedObjects=0
+
+[OptionalObjects]
+SupportedObjects=67
+1=0x1005
+2=0x1008
+3=0x1009
+4=0x100A
+5=0x100C
+6=0x100D
+7=0x1010
+8=0x1011
+9=0x1014
+10=0x1015
+11=0x1016
+12=0x1017
+13=0x1023
+14=0x1029
+15=0x1400
+16=0x1401
+17=0x1402
+18=0x1403
+19=0x1600
+20=0x1601
+21=0x1602
+22=0x1603
+23=0x1800
+24=0x1801
+25=0x1802
+26=0x1803
+27=0x1A00
+28=0x1A01
+29=0x1A02
+30=0x1A03
+31=0x6040
+32=0x6041
+33=0x605A
+34=0x605B
+35=0x605C
+36=0x605D
+37=0x605E
+38=0x6060
+39=0x6061
+40=0x6062
+41=0x6063
+42=0x6064
+43=0x6065
+44=0x6067
+45=0x6068
+46=0x606A
+47=0x606C
+48=0x607A
+49=0x607C
+50=0x607D
+51=0x6081
+52=0x6082
+53=0x6083
+54=0x6084
+55=0x6085
+56=0x608F
+57=0x6098
+58=0x6099
+59=0x609A
+60=0x60B0
+61=0x60B1
+62=0x60C2
+63=0x60F2
+64=0x60FD
+65=0x60FF
+66=0x6502
+67=0x67FF
+
+[1000]
+ParameterName=Device Type
+ObjectType=0x07
+DataType=0x0007
+AccessType=const
+DefaultValue=0xFFFF0192
+PDOMapping=0
+
+[1001]
+ParameterName=Error Register
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+PDOMapping=0
+
+[1005]
+ParameterName=COB-ID SYNC
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000080
+PDOMapping=0
+
+[1008]
+ParameterName=Manufacturer Device Name
+ObjectType=0x07
+DataType=0x0009
+AccessType=const
+PDOMapping=0
+
+[1009]
+ParameterName=Manufacturer Hardware Version
+ObjectType=0x07
+DataType=0x0009
+AccessType=const
+PDOMapping=0
+
+[100A]
+ParameterName=Manufacturer Software Version
+ObjectType=0x07
+DataType=0x0009
+AccessType=const
+PDOMapping=0
+
+[100C]
+ParameterName=Guard Time
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[100D]
+ParameterName=Life Time Factor
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[1010]
+SubNumber=8
+ParameterName=Store Parameter Field
+ObjectType=0x08
+
+[1010sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=5
+AccessType=ro
+DefaultValue=0x7
+PDOMapping=0
+
+[1010sub1]
+ParameterName=Save all Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1010sub2]
+ParameterName=Save Communication Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1010sub3]
+ParameterName=Save Device Profile Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1010sub4]
+ParameterName=Save Axis 0 Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1010sub5]
+ParameterName=Save Axis 1 Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1010sub6]
+ParameterName=Save Axis 2 Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1010sub7]
+ParameterName=Save Device Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[1011]
+SubNumber=8
+ParameterName=Restore Default Parameters
+ObjectType=0x08
+
+[1011sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=5
+AccessType=ro
+DefaultValue=0x7
+PDOMapping=0
+
+[1011sub1]
+ParameterName=Restore all Default Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1011sub2]
+ParameterName=Restore Communication Default Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1011sub3]
+ParameterName=Restore Device Profile Default Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1011sub4]
+ParameterName=Restore Axis 0 Default Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1011sub5]
+ParameterName=Restore Axis 1 Default Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1011sub6]
+ParameterName=Restore Axis 2 Default Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[1011sub7]
+ParameterName=Restore Device Default Parameters
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[1014]
+ParameterName=COB-ID EMCY
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x80
+PDOMapping=0
+
+[1015]
+ParameterName=Inhibit Time Emergency
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x0000
+PDOMapping=0
+
+[1016]
+SubNumber=2
+ParameterName=Heartbeat Consumer Entries
+ObjectType=0x08
+
+[1016sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=5
+AccessType=ro
+DefaultValue=0x1
+PDOMapping=0
+
+[1016sub1]
+ParameterName=Consumer Heartbeat Time 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x0
+PDOMapping=0
+
+[1017]
+ParameterName=Producer Heartbeat Time
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x0
+PDOMapping=0
+
+[1018]
+SubNumber=5
+ParameterName=Identity Object
+ObjectType=0x09
+
+[1018sub0]
+ParameterName=number of entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x4
+PDOMapping=0
+
+[1018sub1]
+ParameterName=Vendor Id
+ObjectType=0x07
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x555
+PDOMapping=0
+
+[1018sub2]
+ParameterName=Product Code
+ObjectType=0x07
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x0
+PDOMapping=0
+
+[1018sub3]
+ParameterName=Revision number
+ObjectType=0x07
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x0
+PDOMapping=0
+
+[1018sub4]
+ParameterName=Serial number
+ObjectType=0x07
+DataType=0x0007
+AccessType=ro
+PDOMapping=0
+
+[1023]
+SubNumber=4
+ParameterName=OS Command
+ObjectType=0x09
+
+[1023sub0]
+ParameterName=NumOfEntries
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x3
+PDOMapping=0
+
+[1023sub1]
+ParameterName=Command
+ObjectType=0x07
+DataType=0x000A
+AccessType=rw
+PDOMapping=0
+ObjFlags=0x00000001
+
+[1023sub2]
+ParameterName=Status
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+PDOMapping=0
+
+[1023sub3]
+ParameterName=Reply
+ObjectType=0x07
+DataType=0x000A
+AccessType=ro
+PDOMapping=0
+
+[1029]
+SubNumber=3
+ParameterName=Error Behaviour
+ObjectType=0x08
+
+[1029sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=5
+AccessType=ro
+DefaultValue=0x2
+PDOMapping=0
+
+[1029sub1]
+ParameterName=Communication Error
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x0
+PDOMapping=0
+
+[1029sub2]
+ParameterName=Application Error
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x1
+PDOMapping=0
+
+[1400]
+SubNumber=3
+ParameterName=Receive PDO Communication Parameter 1
+ObjectType=0x09
+
+[1400sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x02
+PDOMapping=0
+
+[1400sub1]
+ParameterName=COB-ID
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x80000200
+PDOMapping=0
+
+[1400sub2]
+ParameterName=Transmission Type
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0xFF
+PDOMapping=0
+
+[1401]
+SubNumber=3
+ParameterName=Receive PDO Communication Parameter 2
+ObjectType=0x09
+
+[1401sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x02
+PDOMapping=0
+
+[1401sub1]
+ParameterName=COB-ID
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x80000300
+PDOMapping=0
+
+[1401sub2]
+ParameterName=Transmission Type
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0xFF
+PDOMapping=0
+
+[1402]
+SubNumber=3
+ParameterName=Receive PDO Communication Parameter 3
+ObjectType=0x09
+
+[1402sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x02
+PDOMapping=0
+
+[1402sub1]
+ParameterName=COB-ID
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x80000400
+PDOMapping=0
+
+[1402sub2]
+ParameterName=Transmission Type
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0xFF
+PDOMapping=0
+
+[1403]
+SubNumber=3
+ParameterName=Receive PDO Communication Parameter 4
+ObjectType=0x09
+
+[1403sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x02
+PDOMapping=0
+
+[1403sub1]
+ParameterName=COB-ID
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x80000500
+PDOMapping=0
+
+[1403sub2]
+ParameterName=Transmission Type
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0xFE
+PDOMapping=0
+
+[1600]
+SubNumber=4
+ParameterName=Receive PDO Mapping Parameter 1
+ObjectType=0x09
+
+[1600sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x01
+PDOMapping=0
+
+[1600sub1]
+ParameterName=Mapping Entry 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60400010
+PDOMapping=0
+
+[1600sub2]
+ParameterName=Mapping Entry 2
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[1600sub3]
+ParameterName=Mapping Entry 3
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[1601]
+SubNumber=4
+ParameterName=Receive PDO Mapping Parameter 2
+ObjectType=0x09
+
+[1601sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x02
+PDOMapping=0
+
+[1601sub1]
+ParameterName=Mapping Entry 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60400010
+PDOMapping=0
+
+[1601sub2]
+ParameterName=Mapping Entry 2
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60600008
+PDOMapping=0
+
+[1601sub3]
+ParameterName=Mapping Entry 3
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[1602]
+SubNumber=4
+ParameterName=Receive PDO Mapping Parameter 3
+ObjectType=0x09
+
+[1602sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x02
+PDOMapping=0
+
+[1602sub1]
+ParameterName=Mapping Entry 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60400010
+PDOMapping=0
+
+[1602sub2]
+ParameterName=Mapping Entry 2
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x607A0020
+PDOMapping=0
+
+[1602sub3]
+ParameterName=Mapping Entry 3
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[1603]
+SubNumber=4
+ParameterName=Receive PDO Mapping Parameter 4
+ObjectType=0x09
+
+[1603sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x02
+PDOMapping=0
+
+[1603sub1]
+ParameterName=Mapping Entry 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60400010
+PDOMapping=0
+
+[1603sub2]
+ParameterName=Mapping Entry 2
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60FF0020
+PDOMapping=0
+
+[1603sub3]
+ParameterName=Mapping Entry 3
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[1800]
+SubNumber=6
+ParameterName=Transmit PDO Communication Parameter 1
+ObjectType=0x09
+
+[1800sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x05
+PDOMapping=0
+
+[1800sub1]
+ParameterName=COB-ID
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x80000180
+PDOMapping=0
+
+[1800sub2]
+ParameterName=Transmission Type
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x01
+PDOMapping=0
+
+[1800sub3]
+ParameterName=Inhibit Time
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x0
+PDOMapping=0
+
+[1800sub4]
+ParameterName=Compatibility Entry
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+PDOMapping=0
+
+[1800sub5]
+ParameterName=Event Timer
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x0
+PDOMapping=0
+
+[1801]
+SubNumber=6
+ParameterName=Transmit PDO Communication Parameter 2
+ObjectType=0x09
+
+[1801sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x05
+PDOMapping=0
+
+[1801sub1]
+ParameterName=COB-ID
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x80000280
+PDOMapping=0
+
+[1801sub2]
+ParameterName=Transmission Type
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x01
+PDOMapping=0
+
+[1801sub3]
+ParameterName=Inhibit Time
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x0000
+PDOMapping=0
+
+[1801sub4]
+ParameterName=Compatibility Entry
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+PDOMapping=0
+
+[1801sub5]
+ParameterName=Event Timer
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x0000
+PDOMapping=0
+
+[1802]
+SubNumber=6
+ParameterName=Transmit PDO Communication Parameter 3
+ObjectType=0x09
+
+[1802sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x05
+PDOMapping=0
+
+[1802sub1]
+ParameterName=COB-ID
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x80000380
+PDOMapping=0
+
+[1802sub2]
+ParameterName=Transmission Type
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x1
+PDOMapping=0
+
+[1802sub3]
+ParameterName=Inhibit Time
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x0000
+PDOMapping=0
+
+[1802sub4]
+ParameterName=Compatibility Entry
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+PDOMapping=0
+
+[1802sub5]
+ParameterName=Event Timer
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x0000
+PDOMapping=0
+
+[1803]
+SubNumber=6
+ParameterName=Transmit PDO Communication Parameter 4
+ObjectType=0x09
+
+[1803sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+DefaultValue=0x05
+PDOMapping=0
+
+[1803sub1]
+ParameterName=COB-ID
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x80000480
+PDOMapping=0
+
+[1803sub2]
+ParameterName=Transmission Type
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0xFE
+PDOMapping=0
+
+[1803sub3]
+ParameterName=Inhibit Time
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x0000
+PDOMapping=0
+
+[1803sub4]
+ParameterName=Compatibility Entry
+ObjectType=0x07
+DataType=0x0005
+AccessType=ro
+PDOMapping=0
+
+[1803sub5]
+ParameterName=Event Timer
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x0000
+PDOMapping=0
+
+[1A00]
+SubNumber=4
+ParameterName=Transmit PDO Mapping Parameter 1
+ObjectType=0x09
+
+[1A00sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x01
+PDOMapping=0
+
+[1A00sub1]
+ParameterName=Mapping Entry 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60410010
+PDOMapping=0
+
+[1A00sub2]
+ParameterName=Mapping Entry 2
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[1A00sub3]
+ParameterName=Mapping Entry 3
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[1A01]
+SubNumber=4
+ParameterName=Transmit PDO Mapping Parameter 2
+ObjectType=0x09
+
+[1A01sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x02
+PDOMapping=0
+
+[1A01sub1]
+ParameterName=Mapping Entry 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60410010
+PDOMapping=0
+
+[1A01sub2]
+ParameterName=Mapping Entry 2
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60610008
+PDOMapping=0
+
+[1A01sub3]
+ParameterName=Mapping Entry 3
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[1A02]
+SubNumber=4
+ParameterName=Transmit PDO Mapping Parameter 3
+ObjectType=0x09
+
+[1A02sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x02
+PDOMapping=0
+
+[1A02sub1]
+ParameterName=Mapping Entry 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60410010
+PDOMapping=0
+
+[1A02sub2]
+ParameterName=Mapping Entry 2
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60640020
+PDOMapping=0
+
+[1A02sub3]
+ParameterName=Mapping Entry 3
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[1A03]
+SubNumber=4
+ParameterName=Transmit PDO Mapping Parameter 4
+ObjectType=0x09
+
+[1A03sub0]
+ParameterName=Number of Entries
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x02
+PDOMapping=0
+
+[1A03sub1]
+ParameterName=Mapping Entry 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x60410010
+PDOMapping=0
+
+[1A03sub2]
+ParameterName=Mapping Entry 2
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x606C0020
+PDOMapping=0
+
+[1A03sub3]
+ParameterName=Mapping Entry 3
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000000
+PDOMapping=0
+
+[6040]
+ParameterName=Controlword 1
+ObjectType=0x07
+DataType=0x0006
+AccessType=rww
+PDOMapping=1
+
+[6041]
+ParameterName=Statusword 1
+ObjectType=0x07
+DataType=0x0006
+AccessType=ro
+PDOMapping=1
+
+[605A]
+ParameterName=Quick Stop Option Code 1
+ObjectType=0x07
+DataType=0x0003
+AccessType=rw
+DefaultValue=0x0002
+PDOMapping=0
+
+[605B]
+ParameterName=Shutdown Option Code 1
+ObjectType=0x07
+DataType=0x0003
+AccessType=ro
+DefaultValue=0x0000
+PDOMapping=0
+
+[605C]
+ParameterName=Disable Operation Option Code 1
+ObjectType=0x07
+DataType=0x0003
+AccessType=ro
+DefaultValue=0x0001
+PDOMapping=0
+
+[605D]
+ParameterName=Halt Option Code 1
+ObjectType=0x07
+DataType=0x0003
+AccessType=rw
+DefaultValue=0x0001
+PDOMapping=0
+
+[605E]
+ParameterName=Fault Reaction Option Code 1
+ObjectType=0x07
+DataType=0x0003
+AccessType=ro
+DefaultValue=0x0002
+PDOMapping=0
+
+[6060]
+ParameterName=Modes of Operation 1
+ObjectType=0x07
+DataType=0x0002
+AccessType=rww
+DefaultValue=0x00
+PDOMapping=1
+
+[6061]
+ParameterName=Modes of Operation Display 1
+ObjectType=0x07
+DataType=0x0002
+AccessType=ro
+PDOMapping=1
+
+[6062]
+ParameterName=Position Demand Value 1
+ObjectType=0x07
+DataType=0x0004
+AccessType=ro
+PDOMapping=1
+
+[6063]
+ParameterName=Position Actual Internal Value 1
+ObjectType=0x07
+DataType=0x0004
+AccessType=ro
+PDOMapping=1
+
+[6064]
+ParameterName=Position Actual Value 1
+ObjectType=0x07
+DataType=0x0004
+AccessType=ro
+PDOMapping=1
+
+[6065]
+ParameterName=Following Error Window 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[6067]
+ParameterName=Position Window 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0xFFFFFFFF
+PDOMapping=0
+
+[6068]
+ParameterName=Position Window Time 1
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x0000
+PDOMapping=0
+
+[606A]
+ParameterName=Sensor Selection Code 1
+ObjectType=0x07
+DataType=0x0003
+AccessType=rw
+PDOMapping=0
+
+[606C]
+ParameterName=Velocity Actual Value 1
+ObjectType=0x07
+DataType=0x0004
+AccessType=ro
+PDOMapping=1
+
+[607A]
+ParameterName=Target Position 1
+ObjectType=0x07
+DataType=0x0004
+AccessType=rww
+DefaultValue=0x0
+PDOMapping=1
+
+[607C]
+ParameterName=Home Offset 1
+ObjectType=0x07
+DataType=0x0004
+AccessType=rw
+DefaultValue=0x0
+PDOMapping=0
+
+[607D]
+SubNumber=3
+ParameterName=Software Position Limit 1
+ObjectType=0x08
+
+[607Dsub0]
+ParameterName=Highest sub-index supported
+ObjectType=0x07
+DataType=5
+AccessType=const
+DefaultValue=0x2
+PDOMapping=0
+
+[607Dsub1]
+ParameterName=Min Software Position Limit
+ObjectType=0x07
+DataType=0x0004
+AccessType=rw
+DefaultValue=-2147483648
+PDOMapping=0
+
+[607Dsub2]
+ParameterName=Max Software Position Limit
+ObjectType=0x07
+DataType=0x0004
+AccessType=rw
+DefaultValue=2147483647
+PDOMapping=0
+
+[6081]
+ParameterName=Profile Velocity in pp-mode 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[6082]
+ParameterName=End velocity 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x0
+PDOMapping=0
+
+[6083]
+ParameterName=Profile Acceleration 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[6084]
+ParameterName=Profile Deceleration 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[6085]
+ParameterName=Quick Stop Deceleration 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[608F]
+SubNumber=3
+ParameterName=Position Encoder Resolution 1
+ObjectType=0x08
+
+[608Fsub0]
+ParameterName=Highest sub-index supported
+ObjectType=0x07
+DataType=5
+AccessType=const
+DefaultValue=0x00000002
+PDOMapping=0
+
+[608Fsub1]
+ParameterName=Encoder Increments
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[608Fsub2]
+ParameterName=Motor Revolutions
+ObjectType=0x07
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00000001
+PDOMapping=0
+
+[6098]
+ParameterName=Homing Method 1
+ObjectType=0x07
+DataType=0x0002
+AccessType=rw
+DefaultValue=0x00
+PDOMapping=0
+
+[6099]
+SubNumber=3
+ParameterName=Homing Speeds 1
+ObjectType=0x08
+
+[6099sub0]
+ParameterName=Highest sub-index supported
+ObjectType=0x07
+DataType=5
+AccessType=const
+DefaultValue=0x2
+PDOMapping=0
+
+[6099sub1]
+ParameterName=Fast Homing Speed
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[6099sub2]
+ParameterName=Slow Homing Speed
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[609A]
+ParameterName=Homing Acceleration 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=rw
+PDOMapping=0
+
+[60B0]
+ParameterName=Position Offset 1
+ObjectType=0x07
+DataType=0x0004
+AccessType=rw
+DefaultValue=0x0
+PDOMapping=0
+
+[60B1]
+ParameterName=Velocity Offset 1
+ObjectType=0x07
+DataType=0x0004
+AccessType=rw
+DefaultValue=0x00
+PDOMapping=0
+
+[60C2]
+SubNumber=3
+ParameterName=Interpolation Time Period 1
+ObjectType=0x09
+
+[60C2sub0]
+ParameterName=NumOfEntries
+ObjectType=0x07
+DataType=0x0005
+AccessType=const
+DefaultValue=0x02
+PDOMapping=0
+
+[60C2sub1]
+ParameterName=timeUnits
+ObjectType=0x07
+DataType=0x0005
+AccessType=rw
+DefaultValue=0x1
+PDOMapping=0
+
+[60C2sub2]
+ParameterName=timeIndex
+ObjectType=0x07
+DataType=0x0002
+AccessType=rw
+DefaultValue=-2
+PDOMapping=0
+
+[60F2]
+ParameterName=Positioning Option Code 1
+ObjectType=0x07
+DataType=0x0006
+AccessType=rw
+DefaultValue=0x00
+PDOMapping=0
+
+[60FD]
+ParameterName=Digital Inputs 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=ro
+PDOMapping=1
+
+[60FF]
+ParameterName=Target Velocity 1
+ObjectType=0x07
+DataType=0x0004
+AccessType=rw
+DefaultValue=0x0
+PDOMapping=1
+
+[6502]
+ParameterName=Supported Drive Modes 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x000000A5
+PDOMapping=0
+
+[67FF]
+ParameterName=Single Device Type 1
+ObjectType=0x07
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00040192
+PDOMapping=0

--- a/canopen_tests/config/simple/bus.yml
+++ b/canopen_tests/config/simple/bus.yml
@@ -11,9 +11,16 @@ proxy_device_1:
   dcf: "simple.eds"
   driver: "ros2_canopen::ProxyDriver"
   package: "canopen_proxy_driver"
+  polling: true
+  period: 10
+  diagnostics:
+    enable: true
+    period: 1000 # in milliseconds
 
 proxy_device_2:
   node_id: 3
   dcf: "simple.eds"
   driver: "ros2_canopen::ProxyDriver"
   package: "canopen_proxy_driver"
+  polling: true
+  period: 10

--- a/canopen_tests/config/simple_diagnostics/bus.yml
+++ b/canopen_tests/config/simple_diagnostics/bus.yml
@@ -6,18 +6,18 @@ master:
   driver: "ros2_canopen::MasterDriver"
   package: "canopen_master_driver"
 
-proxy_device_1:
-  node_id: 2
+defaults:
   dcf: "simple.eds"
   driver: "ros2_canopen::ProxyDriver"
   package: "canopen_proxy_driver"
   polling: true
   period: 10
+  diagnostics:
+    enable: true
+    period: 1000 # in milliseconds
 
-proxy_device_2:
-  node_id: 3
-  dcf: "simple.eds"
-  driver: "ros2_canopen::ProxyDriver"
-  package: "canopen_proxy_driver"
-  polling: true
-  period: 10
+nodes:
+  proxy_device_1:
+    node_id: 2
+  proxy_device_2:
+    node_id: 3

--- a/canopen_tests/config/simple_diagnostics/simple.eds
+++ b/canopen_tests/config/simple_diagnostics/simple.eds
@@ -1,0 +1,282 @@
+[DeviceInfo]
+VendorName=Lely Industries N.V.
+VendorNumber=0x00000360
+ProductName=
+ProductNumber=0x00000000
+RevisionNumber=0x00000000
+OrderCode=
+BaudRate_10=1
+BaudRate_20=1
+BaudRate_50=1
+BaudRate_125=1
+BaudRate_250=1
+BaudRate_500=1
+BaudRate_800=1
+BaudRate_1000=1
+SimpleBootUpMaster=0
+SimpleBootUpSlave=1
+Granularity=1
+DynamicChannelsSupported=0
+GroupMessaging=0
+NrOfRxPDO=1
+NrOfTxPDO=1
+LSS_Supported=1
+
+[DummyUsage]
+Dummy0001=1
+Dummy0002=1
+Dummy0003=1
+Dummy0004=1
+Dummy0005=1
+Dummy0006=1
+Dummy0007=1
+Dummy0010=1
+Dummy0011=1
+Dummy0012=1
+Dummy0013=1
+Dummy0014=1
+Dummy0015=1
+Dummy0016=1
+Dummy0018=1
+Dummy0019=1
+Dummy001A=1
+Dummy001B=1
+
+[MandatoryObjects]
+SupportedObjects=3
+1=0x1000
+2=0x1001
+3=0x1018
+
+[OptionalObjects]
+SupportedObjects=11
+1=0x1003
+2=0x1005
+3=0x1014
+4=0x1015
+5=0x1016
+6=0x1017
+7=0x1029
+8=0x1400
+9=0x1600
+10=0x1800
+11=0x1A00
+
+[ManufacturerObjects]
+SupportedObjects=4
+1=0x4000
+2=0x4001
+3=0x4002
+4=0x4003
+
+[1000]
+ParameterName=Device type
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00000000
+
+[1001]
+ParameterName=Error register
+DataType=0x0005
+AccessType=ro
+
+[1003]
+ParameterName=Pre-defined error field
+ObjectType=0x08
+DataType=0x0007
+AccessType=ro
+CompactSubObj=254
+
+[1005]
+ParameterName=COB-ID SYNC message
+DataType=0x0007
+AccessType=rw
+DefaultValue=0x00000080
+
+[1014]
+ParameterName=COB-ID EMCY
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x80
+
+[1015]
+ParameterName=Inhibit time EMCY
+DataType=0x0006
+AccessType=rw
+DefaultValue=0
+
+[1016]
+ParameterName=Consumer heartbeat time
+ObjectType=0x08
+DataType=0x0007
+AccessType=rw
+CompactSubObj=1
+
+[1017]
+ParameterName=Producer heartbeat time
+DataType=0x0006
+AccessType=rw
+
+[1018]
+SubNumber=5
+ParameterName=Identity object
+ObjectType=0x09
+
+[1018sub0]
+ParameterName=Highest sub-index supported
+DataType=0x0005
+AccessType=const
+DefaultValue=4
+
+[1018sub1]
+ParameterName=Vendor-ID
+DataType=0x0007
+AccessType=ro
+DefaultValue=0x00000360
+
+[1018sub2]
+ParameterName=Product code
+DataType=0x0007
+AccessType=ro
+
+[1018sub3]
+ParameterName=Revision number
+DataType=0x0007
+AccessType=ro
+
+[1018sub4]
+ParameterName=Serial number
+DataType=0x0007
+AccessType=ro
+
+[1029]
+ParameterName=Error behavior object
+ObjectType=0x08
+DataType=0x0005
+AccessType=rw
+CompactSubObj=1
+
+[1400]
+SubNumber=6
+ParameterName=RPDO communication parameter
+ObjectType=0x09
+
+[1400sub0]
+ParameterName=highest sub-index supported
+DataType=0x0005
+AccessType=const
+DefaultValue=5
+
+[1400sub1]
+ParameterName=COB-ID used by RPDO
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x200
+
+[1400sub2]
+ParameterName=transmission type
+DataType=0x0005
+AccessType=rw
+DefaultValue=0xFF
+
+[1400sub3]
+ParameterName=inhibit time
+DataType=0x0006
+AccessType=rw
+
+[1400sub4]
+ParameterName=compatibility entry
+DataType=0x0005
+AccessType=rw
+
+[1400sub5]
+ParameterName=event-timer
+DataType=0x0006
+AccessType=rw
+
+[1600]
+ParameterName=RPDO mapping parameter
+ObjectType=0x08
+DataType=0x0007
+AccessType=rw
+CompactSubObj=1
+
+[1600Value]
+NrOfEntries=1
+1=0x40000020
+
+[1800]
+SubNumber=7
+ParameterName=TPDO communication parameter
+ObjectType=0x09
+
+[1800sub0]
+ParameterName=highest sub-index supported
+DataType=0x0005
+AccessType=const
+DefaultValue=6
+
+[1800sub1]
+ParameterName=COB-ID used by TPDO
+DataType=0x0007
+AccessType=rw
+DefaultValue=$NODEID+0x180
+
+[1800sub2]
+ParameterName=transmission type
+DataType=0x0005
+AccessType=rw
+DefaultValue=0xFF
+
+[1800sub3]
+ParameterName=inhibit time
+DataType=0x0006
+AccessType=rw
+
+[1800sub4]
+ParameterName=reserved
+DataType=0x0005
+AccessType=rw
+
+[1800sub5]
+ParameterName=event timer
+DataType=0x0006
+AccessType=rw
+
+[1800sub6]
+ParameterName=SYNC start value
+DataType=0x0005
+AccessType=rw
+
+[1A00]
+ParameterName=TPDO mapping parameter
+ObjectType=0x08
+DataType=0x0007
+AccessType=rw
+CompactSubObj=1
+
+[1A00Value]
+NrOfEntries=1
+1=0x40010020
+
+[4000]
+ParameterName=UNSIGNED32 received by slave
+DataType=0x0007
+AccessType=rww
+PDOMapping=1
+
+[4001]
+ParameterName=UNSIGNED32 sent from slave
+DataType=0x0007
+AccessType=rwr
+PDOMapping=1
+
+[4002]
+ParameterName=INTEGER32 test
+DataType=0x0004
+AccessType=rw
+
+[4003]
+ParameterName=INTEGER16 test
+DataType=0x0003
+AccessType=rw

--- a/canopen_tests/launch/analyzers/cia402_diagnostic_analyzer.yaml
+++ b/canopen_tests/launch/analyzers/cia402_diagnostic_analyzer.yaml
@@ -1,0 +1,15 @@
+analyzers:
+  ros__parameters:
+    path: Aggregation
+    cia402_device_1:
+      type: diagnostic_aggregator/GenericAnalyzer
+      path: Cia402Device1
+      contains: [ '/cia402_device_1' ]
+    cia402_device_2:
+      type: diagnostic_aggregator/GenericAnalyzer
+      path: Cia402Device2
+      contains: [ '/cia402_device_2' ]
+    cia402_device_3:
+      type: diagnostic_aggregator/GenericAnalyzer
+      path: Cia402Device3
+      contains: [ '/cia402_device_3' ]

--- a/canopen_tests/launch/analyzers/cia402_diagnostic_analyzer.yaml
+++ b/canopen_tests/launch/analyzers/cia402_diagnostic_analyzer.yaml
@@ -4,12 +4,12 @@ analyzers:
     cia402_device_1:
       type: diagnostic_aggregator/GenericAnalyzer
       path: Cia402Device1
-      contains: [ '/cia402_device_1' ]
+      contains: [ 'cia402_device_1' ]
     cia402_device_2:
       type: diagnostic_aggregator/GenericAnalyzer
       path: Cia402Device2
-      contains: [ '/cia402_device_2' ]
+      contains: [ 'cia402_device_2' ]
     cia402_device_3:
       type: diagnostic_aggregator/GenericAnalyzer
       path: Cia402Device3
-      contains: [ '/cia402_device_3' ]
+      contains: [ 'cia402_device_3' ]

--- a/canopen_tests/launch/analyzers/proxy_diagnostic_analyzer.yaml
+++ b/canopen_tests/launch/analyzers/proxy_diagnostic_analyzer.yaml
@@ -4,8 +4,8 @@ analyzers:
     proxy_device_1:
       type: diagnostic_aggregator/GenericAnalyzer
       path: ProxyDevice1
-      contains: [ '/proxy_device_1' ]
+      contains: [ 'proxy_device_1' ]
     proxy_device_2:
       type: diagnostic_aggregator/GenericAnalyzer
       path: ProxyDevice2
-      contains: [ '/proxy_device_2' ]
+      contains: [ 'proxy_device_2' ]

--- a/canopen_tests/launch/analyzers/proxy_diagnostic_analyzer.yaml
+++ b/canopen_tests/launch/analyzers/proxy_diagnostic_analyzer.yaml
@@ -1,0 +1,11 @@
+analyzers:
+  ros__parameters:
+    path: Aggregation
+    proxy_device_1:
+      type: diagnostic_aggregator/GenericAnalyzer
+      path: ProxyDevice1
+      contains: [ '/proxy_device_1' ]
+    proxy_device_2:
+      type: diagnostic_aggregator/GenericAnalyzer
+      path: ProxyDevice2
+      contains: [ '/proxy_device_2' ]

--- a/canopen_tests/launch/cia402_diagnostics_setup.launch.py
+++ b/canopen_tests/launch/cia402_diagnostics_setup.launch.py
@@ -9,45 +9,59 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 def generate_launch_description():
     slave_eds_path = os.path.join(
-        get_package_share_directory("canopen_tests"), "config", "simple", "simple.eds"
+        get_package_share_directory("canopen_tests"),
+        "config",
+        "cia402_diagnostics",
+        "cia402_slave.eds",
     )
+
     slave_node_1 = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
                 os.path.join(get_package_share_directory("canopen_fake_slaves"), "launch"),
-                "/basic_slave.launch.py",
+                "/cia402_slave.launch.py",
             ]
         ),
         launch_arguments={
             "node_id": "2",
-            "node_name": "slave_node_1",
+            "node_name": "cia402_node_1",
             "slave_config": slave_eds_path,
         }.items(),
     )
-
     slave_node_2 = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
                 os.path.join(get_package_share_directory("canopen_fake_slaves"), "launch"),
-                "/basic_slave.launch.py",
+                "/cia402_slave.launch.py",
             ]
         ),
         launch_arguments={
             "node_id": "3",
-            "node_name": "slave_node_2",
+            "node_name": "cia402_node_2",
             "slave_config": slave_eds_path,
         }.items(),
     )
-
-    print(
-        os.path.join(
-            get_package_share_directory("canopen_tests"),
-            "config",
-            "proxy_write_sdo",
-            "master.dcf",
-        )
+    slave_node_3 = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(get_package_share_directory("canopen_fake_slaves"), "launch"),
+                "/cia402_slave.launch.py",
+            ]
+        ),
+        launch_arguments={
+            "node_id": "4",
+            "node_name": "cia402_node_4",
+            "slave_config": slave_eds_path,
+        }.items(),
     )
-
+    master_bin_path = os.path.join(
+        get_package_share_directory("canopen_tests"),
+        "config",
+        "cia402_diagnostics",
+        "master.bin",
+    )
+    if not os.path.exists(master_bin_path):
+        master_bin_path = ""
     device_container = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
@@ -59,18 +73,34 @@ def generate_launch_description():
             "master_config": os.path.join(
                 get_package_share_directory("canopen_tests"),
                 "config",
-                "simple",
+                "cia402_diagnostics",
                 "master.dcf",
             ),
-            "master_bin": "",
+            "master_bin": master_bin_path,
             "bus_config": os.path.join(
                 get_package_share_directory("canopen_tests"),
                 "config",
-                "simple",
+                "cia402_diagnostics",
                 "bus.yml",
             ),
             "can_interface_name": "vcan0",
         }.items(),
     )
 
-    return LaunchDescription([slave_node_1, slave_node_2, device_container])
+    diagnostics_analyzer_path = os.path.join(
+        get_package_share_directory("canopen_tests"),
+        "launch",
+        "analyzers",
+        "cia402_diagnostic_analyzer.yaml",
+    )
+
+    diagnostics_aggregator_node = launch_ros.actions.Node(
+        package="diagnostic_aggregator",
+        executable="aggregator_node",
+        output="screen",
+        parameters=[diagnostics_analyzer_path],
+    )
+
+    return LaunchDescription(
+        [slave_node_1, slave_node_2, slave_node_3, device_container, diagnostics_aggregator_node]
+    )

--- a/canopen_tests/launch/proxy_diagnostics_setup.launch.py
+++ b/canopen_tests/launch/proxy_diagnostics_setup.launch.py
@@ -9,7 +9,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 
 def generate_launch_description():
     slave_eds_path = os.path.join(
-        get_package_share_directory("canopen_tests"), "config", "simple", "simple.eds"
+        get_package_share_directory("canopen_tests"), "config", "simple_diagnostics", "simple.eds"
     )
     slave_node_1 = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
@@ -59,18 +59,34 @@ def generate_launch_description():
             "master_config": os.path.join(
                 get_package_share_directory("canopen_tests"),
                 "config",
-                "simple",
+                "simple_diagnostics",
                 "master.dcf",
             ),
             "master_bin": "",
             "bus_config": os.path.join(
                 get_package_share_directory("canopen_tests"),
                 "config",
-                "simple",
+                "simple_diagnostics",
                 "bus.yml",
             ),
             "can_interface_name": "vcan0",
         }.items(),
     )
 
-    return LaunchDescription([slave_node_1, slave_node_2, device_container])
+    diagnostics_analyzer_path = os.path.join(
+        get_package_share_directory("canopen_tests"),
+        "launch",
+        "analyzers",
+        "proxy_diagnostic_analyzer.yaml",
+    )
+
+    diagnostics_aggregator_node = launch_ros.actions.Node(
+        package="diagnostic_aggregator",
+        executable="aggregator_node",
+        output="screen",
+        parameters=[diagnostics_analyzer_path],
+    )
+
+    return LaunchDescription(
+        [slave_node_1, slave_node_2, device_container, diagnostics_aggregator_node]
+    )


### PR DESCRIPTION
This pull request introduces the implementation of the diagnostic messages publisher for the [diagnostic_msgs/msg/DiagnosticArray.msg](https://docs.ros2.org/galactic/api/diagnostic_msgs/msg/DiagnosticArray.html) message type. The publisher is responsible for publishing device information, including:

- NMT Status
- EMCY Status
- CiA402:
    - Mode switch status
    - Device state of operation.
 
Reference issue: #104 
Depends on: #115

In order to send the device a diagnostic message, an additional timer callback must be added. Therefore by default, the diagnostic publisher is **disabled**. In order to enable it, add the following to the bus.yml file.

```yml
diagnostics:
    enable: true
    period: 1000 # in milliseconds

[or]

diagnostics:
    enable: true
```
Example: `ros2 launch canopen_tests cia402_diagnostics_setup.launch.py`

### Todo:
- [x] Switch from logging key values to monitor
- [x] Key value structure:
    - Proxy driver: 
        - driver_state
        - nmt_state
        - emcy_state
    - CiA402: (Additional)
        - cia402_state
        - cia402_mode
- [x] Update documentation 

