### PR TITLE
Fix interpolated mode switch in CiA402 System

### DIFF
--- a/canopen_402_driver/include/canopen_402_driver/cia402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/cia402_driver.hpp
@@ -75,6 +75,11 @@ public:
 
   bool set_mode_torque() { return node_canopen_402_driver_->set_mode_torque(); }
 
+  bool set_mode_interpolated_position()
+  {
+    return node_canopen_402_driver_->set_mode_interpolated_position();
+  }
+
   uint16_t get_mode() { return node_canopen_402_driver_->get_mode(); }
 
   bool set_operation_mode(uint16_t mode)

--- a/canopen_402_driver/include/canopen_402_driver/lifecycle_cia402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/lifecycle_cia402_driver.hpp
@@ -76,6 +76,11 @@ public:
   bool set_mode_cyclic_velocity() { return node_canopen_402_driver_->set_mode_cyclic_velocity(); }
 
   bool set_mode_torque() { return node_canopen_402_driver_->set_mode_torque(); }
+
+  bool set_mode_interpolated_position()
+  {
+    return node_canopen_402_driver_->set_mode_interpolated_position();
+  }
 };
 }  // namespace ros2_canopen
 

--- a/canopen_ros2_control/src/cia402_system.cpp
+++ b/canopen_ros2_control/src/cia402_system.cpp
@@ -355,7 +355,8 @@ void Cia402System::switchModes(uint id, const std::shared_ptr<ros2_canopen::Cia4
 
   if (motor_data_[id].interpolated_position_mode.is_commanded())
   {
-    motor_data_[id].interpolated_position_mode.set_response(driver->set_mode_torque());
+    motor_data_[id].interpolated_position_mode.set_response(
+      driver->set_mode_interpolated_position());
   }
 }
 


### PR DESCRIPTION
This PR fixes the missing interpolated mode switch in `Cia402System`. 