### PR TITLE
Use consistenlty (uppercase) HEX output for NodeID and Index.

### DIFF
--- a/canopen_core/src/lifecycle_manager.cpp
+++ b/canopen_core/src/lifecycle_manager.cpp
@@ -124,7 +124,7 @@ unsigned int LifecycleManager::get_state(uint8_t node_id, std::chrono::seconds t
   if (future_status != std::future_status::ready)
   {
     RCLCPP_ERROR(
-      get_logger(), "Server time out while getting current state for node %hhu", node_id);
+      get_logger(), "Server time out while getting current state for node 0x%X", node_id);
     return lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
   }
   auto result = future_result.get()->current_state;
@@ -153,7 +153,7 @@ bool LifecycleManager::change_state(
   if (future_status != std::future_status::ready)
   {
     RCLCPP_ERROR(
-      get_logger(), "Server time out while getting current state for node %hhu", node_id);
+      get_logger(), "Server time out while getting current state for node 0x%X", node_id);
     return false;
   }
 

--- a/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver_impl.hpp
+++ b/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver_impl.hpp
@@ -160,7 +160,7 @@ void NodeCanopenProxyDriver<NODETYPE>::on_nmt(canopen::NmtState nmt_state)
         break;
     }
     RCLCPP_INFO(
-      this->node_->get_logger(), "Slave %hhu: Switched NMT state to %s",
+      this->node_->get_logger(), "Slave 0x%X: Switched NMT state to %s",
       this->lely_driver_->get_id(), message.data.c_str());
 
     nmt_state_publisher->publish(message);
@@ -183,7 +183,7 @@ bool NodeCanopenProxyDriver<NODETYPE>::tpdo_transmit(ros2_canopen::COData & data
   if (this->activated_.load())
   {
     RCLCPP_INFO(
-      this->node_->get_logger(), "Node ID %hhu: Transmit PDO index %x, subindex %hhu, data %d",
+      this->node_->get_logger(), "Node ID 0x%X: Transmit PDO index %x, subindex %hhu, data %d",
       this->lely_driver_->get_id(), data.index_, data.subindex_,
       data.data_);  // ToDo: Remove or make debug
     this->lely_driver_->tpdo_transmit(data);
@@ -198,7 +198,7 @@ void NodeCanopenProxyDriver<NODETYPE>::on_rpdo(ros2_canopen::COData d)
   if (this->activated_.load())
   {
     // RCLCPP_INFO(
-    //   this->node_->get_logger(), "Node ID %hhu: Received PDO index %#04x, subindex %hhu, data
+    //   this->node_->get_logger(), "Node ID 0x%X: Received PDO index %#04x, subindex %hhu, data
     //   %x", this->lely_driver_->get_id(), d.index_, d.subindex_, d.data_);
     auto message = canopen_interfaces::msg::COData();
     message.index = d.index_;
@@ -266,7 +266,7 @@ bool NodeCanopenProxyDriver<NODETYPE>::sdo_read(ros2_canopen::COData & data)
   if (this->activated_.load())
   {
     RCLCPP_INFO(
-      this->node_->get_logger(), "Slave %hhu: SDO Read Call index=0x%x subindex=%hhu",
+      this->node_->get_logger(), "Slave 0x%X: SDO Read Call index=0x%X subindex=%hhu",
       this->lely_driver_->get_id(), data.index_, data.subindex_);
 
     // Only allow one SDO request concurrently
@@ -306,7 +306,7 @@ bool NodeCanopenProxyDriver<NODETYPE>::sdo_write(ros2_canopen::COData & data)
   if (this->activated_.load())
   {
     RCLCPP_INFO(
-      this->node_->get_logger(), "Slave %hhu: SDO Write Call index=0x%x subindex=%hhu data=%u",
+      this->node_->get_logger(), "Slave 0x%X: SDO Write Call index=0x%X subindex=%hhu data=%u",
       this->lely_driver_->get_id(), data.index_, data.subindex_, data.data_);
 
     // Only allow one SDO request concurrently

--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -146,7 +146,7 @@ void CanopenSystem::initDeviceContainer()
     proxy_driver->register_rpdo_cb(rpdo_cb);
 
     RCLCPP_INFO(
-      kLogger, "\nRegistered driver:\n    name: '%s'\n    node_id: '%x'",  //
+      kLogger, "\nRegistered driver:\n    name: '%s'\n    node_id: '0x%X'",  //
       it->second->get_node_base_interface()->get_name(), it->first);
   }
 

--- a/canopen_ros2_control/src/cia402_system.cpp
+++ b/canopen_ros2_control/src/cia402_system.cpp
@@ -72,7 +72,7 @@ void Cia402System::initDeviceContainer()
     driver->register_rpdo_cb(rpdo_cb);
 
     RCLCPP_INFO(
-      kLogger, "\nRegistered driver:\n    name: '%s'\n    node_id: '%x'",
+      kLogger, "\nRegistered driver:\n    name: '%s'\n    node_id: '0x%X'",
       it->second->get_node_base_interface()->get_name(), it->first);
   }
 


### PR DESCRIPTION
Another cosmetic change to make output more readable and debugging simpler. See figure below:

![Screenshot_20230615_120947](https://github.com/ros-industrial/ros2_canopen/assets/1918204/8375ea9a-aa48-4a6c-9f76-6cb2d85f306f)
