### PR TITLE
Do not build dcf-tools bdist in lely_core_libraries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@
 #     pre-commit autoupdate
 #
 # See https://github.com/pre-commit/pre-commit
-
+exclude: '.*\.patch'
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/lely_core_libraries/CMakeLists.txt
+++ b/lely_core_libraries/CMakeLists.txt
@@ -10,8 +10,8 @@ ExternalProject_Add(upstr_lely_core_libraries    # Name for custom target
   GIT_TAG 7824cbb2ac08d091c4fa2fb397669b938de9e3f5
   TIMEOUT 60
   #--Update/Patch step----------
-  UPDATE_COMMAND git am ${CMAKE_CURRENT_SOURCE_DIR}/patches/0001-Don-t-build-bdist.patch
-  COMMAND git am ${CMAKE_CURRENT_SOURCE_DIR}/patches/0002-No-bdist.patch
+  UPDATE_COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/patches/0001-Don-t-build-bdist.patch
+  COMMAND git apply ${CMAKE_CURRENT_SOURCE_DIR}/patches/0002-No-bdist.patch
   #--Configure step-------------
   CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR> COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --disable-cython --disable-doc --disable-tests --disable-static --disable-diag
   #--Build step-----------------

--- a/lely_core_libraries/CMakeLists.txt
+++ b/lely_core_libraries/CMakeLists.txt
@@ -10,7 +10,8 @@ ExternalProject_Add(upstr_lely_core_libraries    # Name for custom target
   GIT_TAG 7824cbb2ac08d091c4fa2fb397669b938de9e3f5
   TIMEOUT 60
   #--Update/Patch step----------
-  # UPDATE_COMMAND mkdir -p <SOURCE_DIR>/include <SOURCE_DIR>/lib
+  UPDATE_COMMAND git am ${CMAKE_CURRENT_SOURCE_DIR}/patches/0001-Don-t-build-bdist.patch
+  COMMAND git am ${CMAKE_CURRENT_SOURCE_DIR}/patches/0002-No-bdist.patch
   #--Configure step-------------
   CONFIGURE_COMMAND autoreconf -i <SOURCE_DIR> COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --disable-cython --disable-doc --disable-tests --disable-static --disable-diag
   #--Build step-----------------

--- a/lely_core_libraries/patches/0001-Don-t-build-bdist.patch
+++ b/lely_core_libraries/patches/0001-Don-t-build-bdist.patch
@@ -1,0 +1,30 @@
+From 10217b41326c2a0a878068558612c774854eb496 Mon Sep 17 00:00:00 2001
+From: Christoph Hellmann Santos <christoph.hellmann.santos@ipa.fraunhofer.de>
+Date: Wed, 21 Jun 2023 08:19:04 +0200
+Subject: [PATCH] Don't build bdist
+
+---
+ python/dcf-tools/Makefile.am | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/python/dcf-tools/Makefile.am b/python/dcf-tools/Makefile.am
+index 9852c84a..58edc597 100644
+--- a/python/dcf-tools/Makefile.am
++++ b/python/dcf-tools/Makefile.am
+@@ -30,13 +30,6 @@ clean-local:
+ 
+ install-exec-local: python-install
+ 
+-.PHONY: python-bdist_wheel
+-python-bdist_wheel:
+-if HAVE_PYTHON3
+-	@$(PYTHON3_ENV) $(PYTHON3) $(srcdir)/setup.py \
+-		bdist_wheel --dist-dir $(dist_dir)
+-endif
+-
+ .PHONY: python-install
+ python-install:
+ if HAVE_PYTHON3
+-- 
+2.34.1
+

--- a/lely_core_libraries/patches/0002-No-bdist.patch
+++ b/lely_core_libraries/patches/0002-No-bdist.patch
@@ -1,0 +1,25 @@
+From e122577c29f833fd5d2d9066c1a1740008d66776 Mon Sep 17 00:00:00 2001
+From: Christoph Hellmann Santos <christoph.hellmann.santos@ipa.fraunhofer.de>
+Date: Wed, 21 Jun 2023 08:25:33 +0200
+Subject: [PATCH] No bdist
+
+---
+ python/dcf-tools/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/python/dcf-tools/Makefile.am b/python/dcf-tools/Makefile.am
+index 58edc597..8a5b2c24 100644
+--- a/python/dcf-tools/Makefile.am
++++ b/python/dcf-tools/Makefile.am
+@@ -23,7 +23,7 @@ EXTRA_DIST += setup.py
+ build_base = $(realpath $(builddir))/build
+ dist_dir = $(realpath $(builddir))/dist
+ 
+-all-local: python-sdist python-bdist_wheel
++all-local: python-sdist
+ 
+ clean-local:
+ 	rm -rf $(build_base) $(dist_dir) $(srcdir)/*.egg-info $(builddir)/*.egg-info
+-- 
+2.34.1
+


### PR DESCRIPTION
Wheel is not available on ros buildfarm. Bdist is not necessary.