### PR TITLE
Update printed output in lely_driver_bridge.cpp

### DIFF
--- a/canopen_base_driver/src/lely_driver_bridge.cpp
+++ b/canopen_base_driver/src/lely_driver_bridge.cpp
@@ -378,7 +378,7 @@ void LelyDriverBridge::tpdo_transmit(COData data)
     }
     tpdo_mapped[data.index_][data.subindex_].WriteEvent();
     std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
-              << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
+              << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_ << " data:"
               << (uint32_t)data.data_ << std::endl;
   }
   catch (lely::canopen::SdoError & e)


### PR DESCRIPTION
add separation between subindex and data in printed output of async_pdo_write to avoid confusion