### PR TITLE
Add boot timeout and retry

### DIFF
--- a/canopen_base_driver/src/lely_driver_bridge.cpp
+++ b/canopen_base_driver/src/lely_driver_bridge.cpp
@@ -71,6 +71,8 @@ std::string LelyBridgeErrCategory::message(int ev) const
     case LelyBridgeErrc::SerialNumberDifference:
       return "Value of object 1018:04 from CANopen device is different to value in object 1F88 "
              "(Serial number).";
+    case LelyBridgeErrc::TimedOut:
+      return "The boot configure process timed out (took more than 1 second).";
     default:
       return "(unrecognized error)";
   }
@@ -110,6 +112,18 @@ void LelyDriverBridge::OnBoot(canopen::NmtState st, char es, const ::std::string
   this->boot_status = es;
   this->boot_what = what;
   boot_cond.notify_all();
+}
+
+void LelyDriverBridge::OnConfig(::std::function<void(::std::error_code ec)> res) noexcept
+{
+  std::cout << "OnConfig" << std::endl;
+  this->SubmitWait(
+    std::chrono::seconds(10),
+    [this, res](std::error_code ec)
+    {
+      std::cout << "OnConfig" << std::endl;
+      FiberDriver::OnConfig(res);
+    });
 }
 
 void LelyDriverBridge::OnRpdoWrite(uint16_t idx, uint8_t subidx) noexcept


### PR DESCRIPTION
This PR will add a boot timout and retry the configuration upload.
Thi should help with the boot issues some users are reporting.

The master will now report that the boot configuration has timed out if it takes longer than 1s.
If the configuration process fails, the master shall retry the configuration once.