### PR TITLE
Removed Cia402RobotController from canopen_ros2_controllers.xml

### DIFF
--- a/canopen_ros2_controllers/canopen_ros2_controllers.xml
+++ b/canopen_ros2_controllers/canopen_ros2_controllers.xml
@@ -11,10 +11,4 @@
       Generic controller for Canopen 402 devices providing service interfaces through ros2_control stack to the can devices.
     </description>
   </class>
-  <class name="canopen_ros2_controllers/Cia402RobotController"
-         type="cia402_robot_controller::Cia402RobotController" base_class_type="controller_interface::ControllerInterface">
-    <description>
-      Generic controller for Canopen 402 devices providing service interfaces through ros2_control stack to the can devices.
-    </description>
-  </class>
 </library>


### PR DESCRIPTION
After the refactor of Cia402RobotController code the xml was not updated. #211