### PR TITLE
Configurable SDO timeout

### DIFF
--- a/canopen/sphinx/user-guide/configuration.rst
+++ b/canopen/sphinx/user-guide/configuration.rst
@@ -151,6 +151,7 @@ device.
   software_version;	The expected software version (default: 0x00000000, see object 1F55).
   configuration_file;	The name of the file containing the configuration (default: "<dcf_path>/<name>.bin" (where <name> is the section name), see object 1F22).
   restore_configuration;	The sub-index of object 1011 to be used when restoring the configuration (default: 0x00).
+  sdo_timeout_ms; The timeout to use for SDO reads/writes to this device. (default: 20ms) 
   sdo;	Additional SDO requests to be sent during configuration (see below).
 
 

--- a/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
@@ -398,6 +398,7 @@ public:
    * @param [in] id       NodeId to connect to
    * @param [in] eds      EDS file
    * @param [in] bin      BIN file (concise dcf)
+   * @param [in] timeout  Timeout in milliseconds for SDO reads/writes
    *
    */
   LelyDriverBridge(

--- a/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
@@ -314,6 +314,8 @@ protected:
 
   uint8_t nodeid;
   std::string name_;
+  
+  std::chrono::milliseconds sdo_timeout;
 
   std::function<void()> on_sync_function_;
 
@@ -400,7 +402,7 @@ public:
    */
   LelyDriverBridge(
     ev_exec_t * exec, canopen::AsyncMaster & master, uint8_t id, std::string name, std::string eds,
-    std::string bin)
+    std::string bin, std::chrono::milliseconds timeout = 20ms)
   : FiberDriver(exec, master, id),
     rpdo_queue(new SafeQueue<COData>()),
     emcy_queue(new SafeQueue<COEmcy>())
@@ -417,6 +419,7 @@ public:
       dictionary_->readDCF(a, b, bin.c_str());
     }
     pdo_map_ = dictionary_->createPDOMapping();
+    sdo_timeout = timeout;
   }
 
   /**
@@ -476,7 +479,7 @@ public:
         this->running = false;
         this->sdo_cond.notify_one();
       },
-      20ms);
+      this->sdo_timeout);
     return prom->get_future();
   }
 
@@ -568,7 +571,7 @@ public:
         this->running = false;
         this->sdo_cond.notify_one();
       },
-      20ms);
+      this->sdo_timeout);
     return prom->get_future();
   }
 
@@ -736,7 +739,7 @@ public:
         this->running = false;
         this->sdo_cond.notify_one();
       },
-      20ms);
+      this->sdo_timeout);
   }
 
   template <typename T>
@@ -763,7 +766,7 @@ public:
         this->running = false;
         this->sdo_cond.notify_one();
       },
-      20ms);
+      this->sdo_timeout);
   }
 
   template <typename T>

--- a/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
@@ -786,7 +786,7 @@ public:
     }
     if (!is_tpdo)
     {
-      if (sync_sdo_read_typed<T>(index, subindex, value, std::chrono::milliseconds(20)))
+      if (sync_sdo_read_typed<T>(index, subindex, value, this->sdo_timeout))
       {
         return value;
       }
@@ -843,7 +843,7 @@ public:
     }
     else
     {
-      sync_sdo_write_typed(index, subindex, value, std::chrono::milliseconds(20));
+      sync_sdo_write_typed(index, subindex, value, this->sdo_timeout);
     }
   }
 };

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
@@ -44,6 +44,7 @@ protected:
   std::mutex driver_mutex_;
   std::shared_ptr<ros2_canopen::LelyDriverBridge> lely_driver_;
   uint32_t period_ms_;
+  int sdo_timeout_ms_;
   bool polling_;
 
   // nmt state callback

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -86,6 +86,16 @@ void NodeCanopenBaseDriver<rclcpp_lifecycle::LifecycleNode>::configure(bool call
     diagnostic_updater_ = std::make_shared<diagnostic_updater::Updater>(this->node_);
     diagnostic_updater_->setHardwareID(std::to_string(this->node_id_));
   }
+
+  std::optional<int> sdo_timeout_ms;
+  try
+  {
+    sdo_timeout_ms = std::optional(this->config_["sdo_timeout_ms"].as<int>());
+  }
+  catch(...)
+  {
+  }
+  sdo_timeout_ms_ = sdo_timeout_ms.value_or(20);
 }
 template <>
 void NodeCanopenBaseDriver<rclcpp::Node>::configure(bool called_from_base)
@@ -141,6 +151,16 @@ void NodeCanopenBaseDriver<rclcpp::Node>::configure(bool called_from_base)
     diagnostic_updater_ = std::make_shared<diagnostic_updater::Updater>(this->node_);
     diagnostic_updater_->setHardwareID(std::to_string(this->node_id_));
   }
+
+  std::optional<int> sdo_timeout_ms;
+  try
+  {
+    sdo_timeout_ms = std::optional(this->config_["sdo_timeout_ms"].as<int>());
+  }
+  catch(...)
+  {
+  }
+  sdo_timeout_ms_ = sdo_timeout_ms.value_or(20);
 }
 
 template <class NODETYPE>
@@ -211,7 +231,7 @@ void NodeCanopenBaseDriver<NODETYPE>::add_to_master()
       std::scoped_lock<std::mutex> lock(this->driver_mutex_);
       this->lely_driver_ = std::make_shared<ros2_canopen::LelyDriverBridge>(
         *(this->exec_), *(this->master_), this->node_id_, this->node_->get_name(), this->eds_,
-        this->bin_);
+        this->bin_, std::chrono::milliseconds(this->sdo_timeout_ms_));
       this->driver_ = std::static_pointer_cast<lely::canopen::BasicDriver>(this->lely_driver_);
       prom->set_value(lely_driver_);
     });

--- a/canopen_master_driver/include/canopen_master_driver/lely_master_bridge.hpp
+++ b/canopen_master_driver/include/canopen_master_driver/lely_master_bridge.hpp
@@ -49,8 +49,6 @@ class LelyMasterBridge : public lely::canopen::AsyncMaster
   bool running;                      ///< Bool to indicate whether an sdo call is running
   std::condition_variable sdo_cond;  ///< Condition variable to sync service calls (one at a time)
   uint8_t node_id;                   ///< Node id of the master
-  std::chrono::milliseconds 
-    sdo_timeout;                     ///< Timeout for SDO reads & writes
 
 public:
   /**
@@ -62,14 +60,11 @@ public:
    * @param [in] dcf_txt      Path to the DCF file
    * @param [in] dcf_bin      Path to the DCF bin file
    * @param [in] id           CANopen node id of the master
-   * @param [in] timeout      Timeout in milliseconds for SDO reads/writes
    */
   LelyMasterBridge(
     ev_exec_t * exec, lely::io::TimerBase & timer, lely::io::CanChannelBase & chan,
-    const std::string & dcf_txt, const std::string & dcf_bin = "", uint8_t id = (uint8_t)255U,
-    std::chrono::milliseconds timeout = 20ms)
-  : lely::canopen::AsyncMaster(exec, timer, chan, dcf_txt, dcf_bin, id), node_id(id),
-    sdo_timeout(timeout)
+    const std::string & dcf_txt, const std::string & dcf_bin = "", uint8_t id = (uint8_t)255U)
+  : lely::canopen::AsyncMaster(exec, timer, chan, dcf_txt, dcf_bin, id), node_id(id)
   {
   }
 
@@ -125,7 +120,7 @@ public:
         this->running = false;
         this->sdo_cond.notify_one();
       },
-      this->sdo_timeout);
+      20ms);
   }
 
   template <typename T>
@@ -150,7 +145,7 @@ public:
         this->running = false;
         this->sdo_cond.notify_one();
       },
-      this->sdo_timeout);
+      20ms);
   }
 };
 


### PR DESCRIPTION
Rather than hardcoding a 20ms timeout for all SDO reads / writes, this PR makes 20ms the default and allows a different value to be specified by setting `sdo_timeout_ms` in the node definition in `bus.yml`.