### PR TITLE
build: export include directories

### DIFF
--- a/canopen_fake_slaves/CMakeLists.txt
+++ b/canopen_fake_slaves/CMakeLists.txt
@@ -66,6 +66,11 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/config/
 )
 
+install(DIRECTORY
+  include/
+  DESTINATION include
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
@@ -77,6 +82,10 @@ if(BUILD_TESTING)
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
+
+ament_export_include_directories(
+  include
+)
 
 ament_export_dependencies(
   ${dependencies}


### PR DESCRIPTION
Export include directory for canopen_fake_slaves to make it possible to derive slaves from the BasicSlave class.

Implements issue: https://github.com/ros-industrial/ros2_canopen/issues/227