### PR TITLE
Update the lely_core_libraries hash to the latest.

### DIFF
--- a/canopen_402_driver/src/command.cpp
+++ b/canopen_402_driver/src/command.cpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 #include "canopen_402_driver/command.hpp"
+#include <stdexcept>
 using namespace ros2_canopen;
 
 const Command402::TransitionTable Command402::transitions_;

--- a/lely_core_libraries/CMakeLists.txt
+++ b/lely_core_libraries/CMakeLists.txt
@@ -11,7 +11,7 @@ ExternalProject_Add(upstr_lely_core_libraries    # Name for custom target
   INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"  # Installation prefix
   BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build
   GIT_REPOSITORY https://gitlab.com/lely_industries/lely-core.git
-  GIT_TAG 7824cbb2ac08d091c4fa2fb397669b938de9e3f5
+  GIT_TAG b63a0b6f79d3ea91dc221724b42dae49894449fc
   TIMEOUT 60
   #UPDATE step apply patch to fix dcf-tools install
   UPDATE_COMMAND


### PR DESCRIPTION
This will fix the building of the lely_core_libraries on Ubuntu 24.04.

This will fix the build as in https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__lely_core_libraries__ubuntu_noble_amd64__binary/8/console