### PR TITLE
Do not export deprecated Lely IO library

### DIFF
--- a/lely_core_libraries/CMakeLists.txt
+++ b/lely_core_libraries/CMakeLists.txt
@@ -47,7 +47,7 @@ install(
     USE_SOURCE_PERMISSIONS)
 
 ament_export_include_directories(include)
-ament_export_libraries(lely-can lely-co lely-coapp lely-ev lely-io2 lely-io lely-libc lely-tap lely-util)
+ament_export_libraries(lely-can lely-co lely-coapp lely-ev lely-io2 lely-libc lely-tap lely-util)
 ament_package(
   CONFIG_EXTRAS
   "cmake/lely_core_libraries-extras.cmake"


### PR DESCRIPTION
See https://opensource.lely.com/canopen/docs/overview/#old-io-library-deprecated

I keep getting old library somehow mixed in my own packages depending on `lely_core_libraries`.
The library is deprecated and no real-world project shall use it anyway.