### PR TITLE
Implement configurable position offsets.

### DIFF
--- a/canopen/sphinx/user-guide/cia402-driver.rst
+++ b/canopen/sphinx/user-guide/cia402-driver.rst
@@ -127,12 +127,18 @@ Additional parameters that can be used in bus.yml for this driver.
   * - scale_pos_to_dev
     - double
     - Scaling factor to convert from SI units to device units for position.
+  * - offset_pos_to_dev
+    - double
+    - Offset in device units added to scaled position commands sent to the device.
   * - scale_vel_to_dev
     - double
     - Scaling factor to convert from SI units to device units for velocity.
   * - scale_pos_from_dev
     - double
     - Scaling factor to convert from device units to SI units for position.
+  * - offset_pos_from_dev
+    - double
+    - Offset in SI units to added to scaled position reports from the device.
   * - scale_vel_from_dev
     - double
     - Scaling factor to convert from device units to SI units for velocity.

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -76,7 +76,10 @@ public:
 
   virtual double get_speed() { return motor_->get_speed() * scale_vel_from_dev_; }
 
-  virtual double get_position() { return motor_->get_position() * scale_pos_from_dev_ + offset_pos_from_dev_; }
+  virtual double get_position()
+  {
+    return motor_->get_position() * scale_pos_from_dev_ + offset_pos_from_dev_;
+  }
 
   virtual uint16_t get_mode() { return motor_->getMode(); }
 

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -57,6 +57,8 @@ protected:
   double scale_pos_from_dev_;
   double scale_vel_to_dev_;
   double scale_vel_from_dev_;
+  double offset_pos_to_dev_;
+  double offset_pos_from_dev_;
   ros2_canopen::State402::InternalState switching_state_;
 
   void publish();
@@ -74,7 +76,7 @@ public:
 
   virtual double get_speed() { return motor_->get_speed() * scale_vel_from_dev_; }
 
-  virtual double get_position() { return motor_->get_position() * scale_pos_from_dev_; }
+  virtual double get_position() { return motor_->get_position() * scale_pos_from_dev_ + offset_pos_from_dev_; }
 
   virtual uint16_t get_mode() { return motor_->getMode(); }
 

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -230,14 +230,14 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
   {
     offset_pos_to_dev = std::optional(this->config_["offset_pos_to_dev"].as<double>());
   }
-  catch(...)
+  catch (...)
   {
   }
-   try
+  try
   {
     offset_pos_from_dev = std::optional(this->config_["offset_from_to_dev"].as<double>());
   }
-  catch(...)
+  catch (...)
   {
   }
   try
@@ -260,8 +260,10 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
     (int)ros2_canopen::State402::InternalState::Operation_Enable);
   RCLCPP_INFO(
     this->node_->get_logger(),
-    "scale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ %f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ %f\n",
-    scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_, offset_pos_to_dev_, offset_pos_from_dev_);
+    "scale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ "
+    "%f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ %f\n",
+    scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_,
+    offset_pos_to_dev_, offset_pos_from_dev_);
 }
 
 template <>
@@ -307,14 +309,14 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
   {
     offset_pos_to_dev = std::optional(this->config_["offset_pos_to_dev"].as<double>());
   }
-  catch(...)
+  catch (...)
   {
   }
-   try
+  try
   {
     offset_pos_from_dev = std::optional(this->config_["offset_from_to_dev"].as<double>());
   }
-  catch(...)
+  catch (...)
   {
   }
   try
@@ -335,10 +337,12 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
   offset_pos_from_dev_ = offset_pos_from_dev.value_or(0.0);
   switching_state_ = (ros2_canopen::State402::InternalState)switching_state.value_or(
     (int)ros2_canopen::State402::InternalState::Operation_Enable);
-   RCLCPP_INFO(
+  RCLCPP_INFO(
     this->node_->get_logger(),
-    "scale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ %f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ %f\n",
-    scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_, offset_pos_to_dev_, offset_pos_from_dev_);
+    "scale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ "
+    "%f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ %f\n",
+    scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_,
+    offset_pos_to_dev_, offset_pos_from_dev_);
 }
 
 template <class NODETYPE>

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -195,6 +195,8 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
   std::optional<double> scale_pos_from_dev;
   std::optional<double> scale_vel_to_dev;
   std::optional<double> scale_vel_from_dev;
+  std::optional<double> offset_pos_to_dev;
+  std::optional<double> offset_pos_from_dev;
   std::optional<int> switching_state;
   try
   {
@@ -226,6 +228,20 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
   }
   try
   {
+    offset_pos_to_dev = std::optional(this->config_["offset_pos_to_dev"].as<double>());
+  }
+  catch(...)
+  {
+  }
+   try
+  {
+    offset_pos_from_dev = std::optional(this->config_["offset_from_to_dev"].as<double>());
+  }
+  catch(...)
+  {
+  }
+  try
+  {
     switching_state = std::optional(this->config_["switching_state"].as<int>());
   }
   catch (...)
@@ -238,12 +254,14 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
   scale_pos_from_dev_ = scale_pos_from_dev.value_or(0.001);
   scale_vel_to_dev_ = scale_vel_to_dev.value_or(1000.0);
   scale_vel_from_dev_ = scale_vel_from_dev.value_or(0.001);
+  offset_pos_to_dev_ = offset_pos_to_dev.value_or(0.0);
+  offset_pos_from_dev_ = offset_pos_from_dev.value_or(0.0);
   switching_state_ = (ros2_canopen::State402::InternalState)switching_state.value_or(
     (int)ros2_canopen::State402::InternalState::Operation_Enable);
   RCLCPP_INFO(
     this->node_->get_logger(),
-    "scale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ %f\n",
-    scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_);
+    "scale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ %f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ %f\n",
+    scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_, offset_pos_to_dev_, offset_pos_from_dev_);
 }
 
 template <>
@@ -254,6 +272,8 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
   std::optional<double> scale_pos_from_dev;
   std::optional<double> scale_vel_to_dev;
   std::optional<double> scale_vel_from_dev;
+  std::optional<double> offset_pos_to_dev;
+  std::optional<double> offset_pos_from_dev;
   std::optional<int> switching_state;
   try
   {
@@ -285,6 +305,20 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
   }
   try
   {
+    offset_pos_to_dev = std::optional(this->config_["offset_pos_to_dev"].as<double>());
+  }
+  catch(...)
+  {
+  }
+   try
+  {
+    offset_pos_from_dev = std::optional(this->config_["offset_from_to_dev"].as<double>());
+  }
+  catch(...)
+  {
+  }
+  try
+  {
     switching_state = std::optional(this->config_["switching_state"].as<int>());
   }
   catch (...)
@@ -297,12 +331,14 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
   scale_pos_from_dev_ = scale_pos_from_dev.value_or(0.001);
   scale_vel_to_dev_ = scale_vel_to_dev.value_or(1000.0);
   scale_vel_from_dev_ = scale_vel_from_dev.value_or(0.001);
+  offset_pos_to_dev_ = offset_pos_to_dev.value_or(0.0);
+  offset_pos_from_dev_ = offset_pos_from_dev.value_or(0.0);
   switching_state_ = (ros2_canopen::State402::InternalState)switching_state.value_or(
     (int)ros2_canopen::State402::InternalState::Operation_Enable);
-  RCLCPP_INFO(
+   RCLCPP_INFO(
     this->node_->get_logger(),
-    "scale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ %f\n",
-    scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_);
+    "scale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ %f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ %f\n",
+    scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_, offset_pos_to_dev_, offset_pos_from_dev_);
 }
 
 template <class NODETYPE>
@@ -334,7 +370,7 @@ void NodeCanopen402Driver<NODETYPE>::publish()
 {
   sensor_msgs::msg::JointState js_msg;
   js_msg.name.push_back(this->node_->get_name());
-  js_msg.position.push_back(motor_->get_position() * scale_pos_from_dev_);
+  js_msg.position.push_back(motor_->get_position() * scale_pos_from_dev_ + offset_pos_from_dev_);
   js_msg.velocity.push_back(motor_->get_speed() * scale_vel_from_dev_);
   js_msg.effort.push_back(0.0);
   publish_joint_state->publish(js_msg);
@@ -446,7 +482,7 @@ void NodeCanopen402Driver<NODETYPE>::handle_set_target(
       (mode == MotorBase::Profiled_Position) or (mode == MotorBase::Cyclic_Synchronous_Position) or
       (mode == MotorBase::Interpolated_Position))
     {
-      target = request->target * scale_pos_to_dev_;
+      target = request->target * scale_pos_to_dev_ + offset_pos_to_dev_;
     }
     else if (
       (mode == MotorBase::Velocity) or (mode == MotorBase::Profiled_Velocity) or
@@ -665,7 +701,7 @@ bool NodeCanopen402Driver<NODETYPE>::set_target(double target)
       (mode == MotorBase::Profiled_Position) or (mode == MotorBase::Cyclic_Synchronous_Position) or
       (mode == MotorBase::Interpolated_Position))
     {
-      scaled_target = target * scale_pos_to_dev_;
+      scaled_target = target * scale_pos_to_dev_ + offset_pos_to_dev_;
     }
     else if (
       (mode == MotorBase::Velocity) or (mode == MotorBase::Profiled_Velocity) or


### PR DESCRIPTION
This PR adds the parameters `offset_pos_to_dev` and `offset_pos_from_dev` to `bus.yml` to allow user-defined offsets in the position feedback and commands. These default to zero if not specified.

One use case is remapping the sense of rotation and angle convention for a joint with an absolute angle encoder whose rotation direction cannot be reversed physically or electronically. 

Assuming full-scale encoder count $n_{fs}$ and current count $n_{enc}$, mapping position feedback from the device, with `offset_pos_from_dev = 2*pi`, `scale_pos_from_dev = -2*pi/n_fs`:

$$\large \theta = 2\pi - \frac{2\pi}{n_{fs}}n_{enc}$$

Mapping commands to the device, with `offset_pos_to_dev = n_fs`, `scale_pos_to_dev = -n_fs/(2*pi)`:

$$\large n_{enc} = n_{fs} - \frac{n_{fs}}{2\pi}\theta$$

This could also be useful for absolute position encoders that otherwise cannot be zeroed at a given physical position.