### PR TITLE
Add suported modes to `canopen_fake_slaves` README

### DIFF
--- a/canopen_fake_slaves/Readme.md
+++ b/canopen_fake_slaves/Readme.md
@@ -5,3 +5,6 @@
 Supported modes:
 * Cyclic Position
 * Profiled Position (Thanks to motion generator https://github.com/EFeru/MotionGenerator)
+* Interpolated Position
+* Homing
+* Profiled Velocity


### PR DESCRIPTION
I noticed that actually three more modes are supported currently by the code. 

I believe that `Profiled Velocity` here is not well implemented (i.e. no accelleration ramps are implemented, velocity is directly and abruptly changed) but, at least for some mocking purposes,  the mode is already supported in the sense that user won't get an error by requesting mode switching to `profiled velocity`.