### PR TITLE
Fix uninitialization issues

### DIFF
--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -220,7 +220,9 @@ template <class NODETYPE>
 void NodeCanopenBaseDriver<NODETYPE>::deactivate(bool called_from_base)
 {
   nmt_state_publisher_thread_.join();
-  poll_timer_->cancel();
+  if (poll_timer_) {
+    poll_timer_->cancel();
+  }
   emcy_queue_.reset();
   rpdo_queue_.reset();
   if (diagnostic_enabled_.load())

--- a/canopen_core/include/canopen_core/device_container.hpp
+++ b/canopen_core/include/canopen_core/device_container.hpp
@@ -75,6 +75,8 @@ public:
     lifecycle_operation_ = false;
   }
 
+  ~DeviceContainer() override { shutdown(); }
+
   /**
    * @brief Executes the initialisation
    *

--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -48,7 +48,10 @@ void CanopenSystem::clean()
   device_container_.reset();
   executor_.reset();
 
-  init_thread_->join();
+  if (init_thread_->joinable())
+  {
+    init_thread_->join();
+  }
   init_thread_.reset();
 
   executor_.reset();


### PR DESCRIPTION
Fix issues found while implementing tests caused by improper uninitialization:

- `poll_timer_` not set when polling_ is disabled
- DeviceContainer's `shutdown()` is not called anywhere. In particular it needs to be called at least from CanopenSystem::clean(), but this way is more generic.
- `init_thread` is already joined in the contructor. This thread should be removed in the future.