### PR TITLE
Disable some prints in the success path of TPDO transfers

### DIFF
--- a/canopen_base_driver/src/lely_driver_bridge.cpp
+++ b/canopen_base_driver/src/lely_driver_bridge.cpp
@@ -377,9 +377,9 @@ void LelyDriverBridge::tpdo_transmit(COData data)
       sub->setVal<CO_DEFTYPE_INTEGER32>(val);
     }
     tpdo_mapped[data.index_][data.subindex_].WriteEvent();
-    std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
-              << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
-              << " data:" << (uint32_t)data.data_ << std::endl;
+    // std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
+    //           << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
+    //           << " data:" << (uint32_t)data.data_ << std::endl;
   }
   catch (lely::canopen::SdoError & e)
   {

--- a/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver_impl.hpp
+++ b/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver_impl.hpp
@@ -182,10 +182,9 @@ bool NodeCanopenProxyDriver<NODETYPE>::tpdo_transmit(ros2_canopen::COData & data
 {
   if (this->activated_.load())
   {
-    RCLCPP_INFO(
-      this->node_->get_logger(), "Node ID 0x%X: Transmit PDO index %x, subindex %hhu, data %d",
-      this->lely_driver_->get_id(), data.index_, data.subindex_,
-      data.data_);  // ToDo: Remove or make debug
+    // RCLCPP_INFO(
+    //   this->node_->get_logger(), "Node ID 0x%X: Transmit PDO index %x, subindex %hhu, data %d",
+    //   this->lely_driver_->get_id(), data.index_, data.subindex_, data.data_);
     this->lely_driver_->tpdo_transmit(data);
     return true;
   }


### PR DESCRIPTION
These 2 prints are part of the "success" path of TPDO transfers and cause a lot of noise on stdout.