### PR TITLE
Fixing ID type in storage of ros2_control system.

### DIFF
--- a/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
@@ -243,7 +243,7 @@ protected:
   std::shared_ptr<ros2_canopen::DeviceContainer> device_container_;
   std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
   // can stuff
-  std::map<uint, CanopenNodeData> canopen_data_;
+  std::map<uint16_t, CanopenNodeData> canopen_data_;
   // threads
   std::unique_ptr<std::thread> spin_thread_;
   std::unique_ptr<std::thread> init_thread_;


### PR DESCRIPTION
As we are now running all our packages with the GCC flags from ros2_control (see [here](https://github.com/ros-controls/ros2_control_cmake/blob/master/ros2_control_cmake/cmake/ros2_control.cmake#L37-L39)), there are some compilation errors with the data conversion.

This fix makes the data more correct. Or should it even be ˙uint8_t`?