### PR TITLE
Fix command interfaces value missmatch.

### DIFF
--- a/canopen_ros2_controllers/src/canopen_proxy_controller.cpp
+++ b/canopen_ros2_controllers/src/canopen_proxy_controller.cpp
@@ -327,9 +327,12 @@ controller_interface::return_type CanopenProxyController::update(
   }
   else if (propagate_controller_command_msg(*current_cmd))
   {
-    command_interfaces_[CommandInterfaces::TPDO_INDEX].set_value((*current_cmd)->index);
-    command_interfaces_[CommandInterfaces::TPDO_SUBINDEX].set_value((*current_cmd)->subindex);
-    command_interfaces_[CommandInterfaces::TPDO_DATA].set_value((*current_cmd)->data);
+    command_interfaces_[CommandInterfaces::TPDO_INDEX].set_value(
+        static_cast<double>((*current_cmd)->index));
+    command_interfaces_[CommandInterfaces::TPDO_SUBINDEX].set_value(
+        static_cast<double>((*current_cmd)->subindex));
+    command_interfaces_[CommandInterfaces::TPDO_DATA].set_value(
+        static_cast<double>((*current_cmd)->data));
     // tpdo data one shot mechanism
     command_interfaces_[CommandInterfaces::TPDO_ONS].set_value(kCommandValue);
 


### PR DESCRIPTION
Adding a quick value missmatch fix that helps the package compile with the latest release version of `ros2_control`.

It seems that `ros2_control` had breaking changes that brake `canopen_ros2_controllers` in ROS 2 Jazzy (and probably Rolling):

https://build.ros2.org/view/Jbin_uN64/job/Jbin_uN64__canopen_ros2_controllers__ubuntu_noble_amd64__binary/

I wanted to run a `Jazzy` sync soon and this package is in a regression:

https://repo.ros2.org/status_page/ros_jazzy_default.html?q=REGRESSION

@ipa-vsp It would be great if we can release a fix to Jazzy ASAP otherwise the package will get whipped out on the sync.



