### PR TITLE
Boot Timeout: Add parameter to base driver to pass to wait as timeout

### DIFF
--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver.hpp
@@ -45,6 +45,7 @@ protected:
   std::shared_ptr<ros2_canopen::LelyDriverBridge> lely_driver_;
   uint32_t period_ms_;
   int sdo_timeout_ms_;
+  int boot_timeout_ms_;
   bool polling_;
 
   // nmt state callback

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -108,6 +108,16 @@ void NodeCanopenBaseDriver<rclcpp_lifecycle::LifecycleNode>::configure(bool call
   {
   }
   sdo_timeout_ms_ = sdo_timeout_ms.value_or(20);
+
+  std::optional<int> boot_timeout_ms;
+  try
+  {
+    boot_timeout_ms = std::optional(this->config_["boot_timeout_ms"].as<int>());
+  }
+  catch (...)
+  {
+  }
+  boot_timeout_ms_ = boot_timeout_ms.value_or(20);
 }
 template <>
 void NodeCanopenBaseDriver<rclcpp::Node>::configure(bool called_from_base)
@@ -185,6 +195,16 @@ void NodeCanopenBaseDriver<rclcpp::Node>::configure(bool called_from_base)
   {
   }
   sdo_timeout_ms_ = sdo_timeout_ms.value_or(20);
+
+  std::optional<int> boot_timeout_ms;
+  try
+  {
+    boot_timeout_ms = std::optional(this->config_["boot_timeout_ms"].as<int>());
+  }
+  catch (...)
+  {
+  }
+  boot_timeout_ms_ = boot_timeout_ms.value_or(20);
 }
 
 template <class NODETYPE>
@@ -255,7 +275,8 @@ void NodeCanopenBaseDriver<NODETYPE>::add_to_master()
       std::scoped_lock<std::mutex> lock(this->driver_mutex_);
       this->lely_driver_ = std::make_shared<ros2_canopen::LelyDriverBridge>(
         *(this->exec_), *(this->master_), this->node_id_, this->node_->get_name(), this->eds_,
-        this->bin_, std::chrono::milliseconds(this->sdo_timeout_ms_));
+        this->bin_, std::chrono::milliseconds(this->sdo_timeout_ms_),
+        std::chrono::milliseconds(this->boot_timeout_ms_));
       this->driver_ = std::static_pointer_cast<lely::canopen::BasicDriver>(this->lely_driver_);
       prom->set_value(lely_driver_);
     });


### PR DESCRIPTION
I ran into issue #342 when launching multiple instances of the same driver. 

On some boots, there are no issues and all devices are initialized correctly. However, the majority of the time, one driver will get stuck on the `wait_for_boot` function, waiting for the condition variable `boot_cond` to get notified. 

I have not yet determined why this happens, but when it does, the entire container needs to be sent a SIGKILL to stop it. 

I propose adding a `boot_timeout_ms` parameter to the base driver that is then passed to the condition variable using a `wait_for` instead of `wait`. This way, once the timeout elapses, the driver will continue, and if the device was not initialized, it will crash but will not stay in an endless wait. 