### PR TITLE
fix(canopen_ros2_control): return ERROR for non-zero EMCY

### DIFF
--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -292,10 +292,11 @@ hardware_interface::return_type CanopenSystem::read(
         canopen_data.emcy_data.original_emcy.msef[0], canopen_data.emcy_data.original_emcy.msef[1],
         canopen_data.emcy_data.original_emcy.msef[2], canopen_data.emcy_data.original_emcy.msef[3],
         canopen_data.emcy_data.original_emcy.msef[4]);
+      return hardware_interface::return_type::ERROR;
     }
   }
 
-  return hardware_interface::return_type::ERROR;
+  return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type CanopenSystem::write(


### PR DESCRIPTION
Return ERROR when the error code is non-zero. Return OK if otherwise.