### PR TITLE
Add boot timeout and retry

### DIFF
--- a/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
@@ -312,7 +312,7 @@ protected:
   canopen::NmtState boot_state;
   std::condition_variable boot_cond;
   std::mutex boot_mtex;
-  std::chrono::milliseconds boot_timeout;
+  std::chrono::milliseconds boot_timeout_;
 
   uint8_t nodeid;
   std::string name_;
@@ -426,7 +426,7 @@ public:
     }
     pdo_map_ = dictionary_->createPDOMapping();
     sdo_timeout = timeout;
-    boot_timeout = std::chrono::milliseconds(2000);
+    boot_timeout_ = boot_timeout;
   }
 
   /**
@@ -681,7 +681,7 @@ public:
     if (booted.load()) return true;
 
     std::unique_lock<std::mutex> lck(boot_mtex);
-    auto status = boot_cond.wait_for(lck, std::chrono::seconds(1));
+    auto status = boot_cond.wait_for(lck, boot_timeout_);
 
     if (status == std::cv_status::timeout)
     {

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -311,17 +311,21 @@ void NodeCanopenBaseDriver<NODETYPE>::add_to_master()
 
         if (boot_attempts < max_boot_attempts)
         {
+          RCLCPP_INFO(this->node_->get_logger(), "Sending NMT reset before retrying boot");
+          this->lely_driver_->nmt_command(canopen::NmtCommand::RESET_NODE);
           this->lely_driver_->Boot();  // Trigger boot again
           RCLCPP_WARN(this->node_->get_logger(), "Retrying boot configuration...");
         }
         else
         {
           RCLCPP_ERROR(this->node_->get_logger(), "Boot failed after %d attempts", boot_attempts);
-          // TODO: (ipa-vsp) Handle failure case
-          // You might want to set a flag or throw an exception here
-          // to indicate that the device is not ready.
         }
       }
+    }
+    if (!boot_success)
+    {
+      throw DriverException(
+        std::string("Boot failed after ") + std::to_string(boot_attempts) + " attempts");
     }
   }
 

--- a/canopen_base_driver/src/lely_driver_bridge.cpp
+++ b/canopen_base_driver/src/lely_driver_bridge.cpp
@@ -71,6 +71,8 @@ std::string LelyBridgeErrCategory::message(int ev) const
     case LelyBridgeErrc::SerialNumberDifference:
       return "Value of object 1018:04 from CANopen device is different to value in object 1F88 "
              "(Serial number).";
+    case LelyBridgeErrc::TimeOut:
+      return "The boot configure process timed out (took more than 1 second).";
     default:
       return "(unrecognized error)";
   }
@@ -109,8 +111,22 @@ void LelyDriverBridge::OnBoot(canopen::NmtState st, char es, const ::std::string
   this->boot_state = st;
   this->boot_status = es;
   this->boot_what = what;
+  std::cout << "OnBoot: id=" << (unsigned int)this->get_id() << " state=" << (int)st
+            << " status=" << (int)es << " what=" << what << std::endl;
   boot_cond.notify_all();
 }
+
+// void LelyDriverBridge::OnConfig(::std::function<void(::std::error_code ec)> res) noexcept
+// {
+//   std::cout << "OnConfig" << std::endl;
+//   this->SubmitWait(
+//     std::chrono::seconds(10),
+//     [this, res](std::error_code ec)
+//     {
+//       std::cout << "OnConfig" << std::endl;
+//       FiberDriver::OnConfig(res);
+//     });
+// }
 
 void LelyDriverBridge::OnRpdoWrite(uint16_t idx, uint8_t subidx) noexcept
 {

--- a/canopen_base_driver/src/lely_driver_bridge.cpp
+++ b/canopen_base_driver/src/lely_driver_bridge.cpp
@@ -72,7 +72,7 @@ std::string LelyBridgeErrCategory::message(int ev) const
       return "Value of object 1018:04 from CANopen device is different to value in object 1F88 "
              "(Serial number).";
     case LelyBridgeErrc::TimeOut:
-      return "The boot configure process timed out (took more than 1 second).";
+      return "The boot configure process timeout!";
     default:
       return "(unrecognized error)";
   }
@@ -111,8 +111,6 @@ void LelyDriverBridge::OnBoot(canopen::NmtState st, char es, const ::std::string
   this->boot_state = st;
   this->boot_status = es;
   this->boot_what = what;
-  std::cout << "OnBoot: id=" << (unsigned int)this->get_id() << " state=" << (int)st
-            << " status=" << (int)es << " what=" << what << std::endl;
   boot_cond.notify_all();
 }
 

--- a/canopen_fake_slaves/include/canopen_fake_slaves/cia402_slave.hpp
+++ b/canopen_fake_slaves/include/canopen_fake_slaves/cia402_slave.hpp
@@ -800,6 +800,25 @@ protected:
   }
 };
 
+class DelayedBootSlave : public ros2_canopen::CIA402MockSlave
+{
+public:
+  using ros2_canopen::CIA402MockSlave::CIA402MockSlave;
+
+  void DelayedReset()
+  {
+    RCLCPP_WARN(rclcpp::get_logger("cia402_slave"), "Delaying CANopen Boot-Up Frame...");
+    std::thread(
+      [this]()
+      {
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+        RCLCPP_INFO(rclcpp::get_logger("cia402_slave"), "Now sending Boot-Up frame...");
+        this->canopen::BasicSlave::Reset();
+      })
+      .detach();
+  }
+};
+
 class CIA402Slave : public BaseSlave
 {
 public:
@@ -836,8 +855,8 @@ public:
         ctx.shutdown();
       });
 
-    ros2_canopen::CIA402MockSlave slave(timer, chan, slave_config_.c_str(), "", node_id_);
-    slave.Reset();
+    DelayedBootSlave slave(timer, chan, slave_config_.c_str(), "", node_id_);
+    slave.DelayedReset();
 
     RCLCPP_INFO(this->get_logger(), "Created cia402 slave for node_id %i.", node_id_);
 

--- a/canopen_fake_slaves/include/canopen_fake_slaves/cia402_slave.hpp
+++ b/canopen_fake_slaves/include/canopen_fake_slaves/cia402_slave.hpp
@@ -811,7 +811,7 @@ public:
     std::thread(
       [this]()
       {
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         RCLCPP_INFO(rclcpp::get_logger("cia402_slave"), "Now sending Boot-Up frame...");
         this->canopen::BasicSlave::Reset();
       })

--- a/canopen_ros2_controllers/src/canopen_proxy_controller.cpp
+++ b/canopen_ros2_controllers/src/canopen_proxy_controller.cpp
@@ -328,11 +328,11 @@ controller_interface::return_type CanopenProxyController::update(
   else if (propagate_controller_command_msg(*current_cmd))
   {
     command_interfaces_[CommandInterfaces::TPDO_INDEX].set_value(
-        static_cast<double>((*current_cmd)->index));
+      static_cast<double>((*current_cmd)->index));
     command_interfaces_[CommandInterfaces::TPDO_SUBINDEX].set_value(
-        static_cast<double>((*current_cmd)->subindex));
+      static_cast<double>((*current_cmd)->subindex));
     command_interfaces_[CommandInterfaces::TPDO_DATA].set_value(
-        static_cast<double>((*current_cmd)->data));
+      static_cast<double>((*current_cmd)->data));
     // tpdo data one shot mechanism
     command_interfaces_[CommandInterfaces::TPDO_ONS].set_value(kCommandValue);
 

--- a/canopen_tests/config/cia402/bus.yml
+++ b/canopen_tests/config/cia402/bus.yml
@@ -13,6 +13,7 @@ defaults:
   package: "canopen_402_driver"
   period: 10
   revision_number: 0
+  boot_timeout_ms: 1000
   sdo:
     - {index: 0x60C2, sub_index: 1, value: 50} # Set interpolation time for cyclic modes to 50 ms
     - {index: 0x60C2, sub_index: 2, value: -3} # Set base 10-3s
@@ -55,13 +56,13 @@ nodes:
   cia402_device_1:
     node_id: 2
     namespace: "/test1"
-  cia402_device_2:
-    node_id: 3
-  cia402_device_3:
-    node_id: 4
-  cia402_device_4:
-    node_id: 5
-  cia402_device_5:
-    node_id: 6
-  cia402_device_6:
-    node_id: 7
+  # cia402_device_2:
+  #   node_id: 3
+  # cia402_device_3:
+  #   node_id: 4
+  # cia402_device_4:
+  #   node_id: 5
+  # cia402_device_5:
+  #   node_id: 6
+  # cia402_device_6:
+  #   node_id: 7


### PR DESCRIPTION
Continued from #205. 

This should fix the issue where the driver is stuck in `wait for boot`. Now, the driver will try to boot three times, with a new parameter called `boot_timeout_ms` that can be set in the *bus.yml*. If it fails after three attempts, the driver will exit itself. 