### PR TITLE
Typo in node_canopen_402_driver_impl.hpp - "offset_pos_from_dev"

### DIFF
--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -349,7 +349,7 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
   }
   try
   {
-    offset_pos_from_dev = std::optional(this->config_["offset_from_to_dev"].as<double>());
+    offset_pos_from_dev = std::optional(this->config_["offset_pos_from_dev"].as<double>());
   }
   catch (...)
   {


### PR DESCRIPTION
"offset_from_to_dev" --> "offset_pos_from_dev"