### PR TITLE
fix(driver): fix lifecycle node deactivate crash

### DIFF
--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -401,7 +401,11 @@ template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::deactivate(bool called_from_base)
 {
   NodeCanopenProxyDriver<NODETYPE>::deactivate(false);
-  timer_->cancel();
+  if(timer_ != nullptr){
+     timer_->cancel(); 
+  }
+  this->exec_->post([this]() { motor_.reset(); });
+
 }
 
 template <class NODETYPE>

--- a/canopen_core/src/lifecycle_manager.cpp
+++ b/canopen_core/src/lifecycle_manager.cpp
@@ -78,8 +78,11 @@ bool LifecycleManager::load_from_config()
   for (auto it = devices.begin(); it != devices.end(); it++)
   {
     uint8_t node_id = config_->get_entry<uint8_t>(*it, "node_id").value();
-    std::string change_state_client_name = *it;
-    std::string get_state_client_name = *it;
+    std::string device_namespace = config_->get_entry<std::string>(*it, "namespace").value();
+    device_namespace += "/";
+    device_namespace += *it;
+    std::string change_state_client_name = device_namespace;
+    std::string get_state_client_name = device_namespace;
     get_state_client_name += "/get_state";
     change_state_client_name += "/change_state";
     RCLCPP_INFO(this->get_logger(), "Found %s (node_id=%hu)", it->c_str(), node_id);


### PR DESCRIPTION
using
```
driver: "ros2_canopen::LifecycleCia402Driver"
package: "canopen_402_driver"
  driver: "ros2_canopen::LifecycleMasterDriver"
  package: "canopen_master_driver"
```
Executing the following commands will cause a crash
```
ros2 lifecycle set /lifecycle_manager configure
ros2 lifecycle set /lifecycle_manager activate


ros2 lifecycle set /lifecycle_manager deactivate
ros2 lifecycle set /lifecycle_manager cleanup
```