### PR TITLE
Fix data conversion in the Lely Bridge to enable more data types and proper handling of Emcy in ros2_control

### DIFF
--- a/canopen_base_driver/src/lely_driver_bridge.cpp
+++ b/canopen_base_driver/src/lely_driver_bridge.cpp
@@ -138,41 +138,60 @@ void LelyDriverBridge::OnRpdoWrite(uint16_t idx, uint8_t subidx) noexcept
   }
   uint8_t co_def = (uint8_t)sub->getType();
   uint32_t data = 0;
-  if (co_def == CO_DEFTYPE_UNSIGNED8)
+  switch (co_def)
   {
-    std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-    sub->setVal<CO_DEFTYPE_UNSIGNED8>((uint8_t)rpdo_mapped[idx][subidx]);
-    std::memcpy(&data, &sub->getVal<CO_DEFTYPE_UNSIGNED8>(), 1);
-  }
-  if (co_def == CO_DEFTYPE_INTEGER8)
-  {
-    std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-    sub->setVal<CO_DEFTYPE_INTEGER8>((int8_t)rpdo_mapped[idx][subidx]);
-    std::memcpy(&data, &sub->getVal<CO_DEFTYPE_INTEGER8>(), 1);
-  }
-  if (co_def == CO_DEFTYPE_UNSIGNED16)
-  {
-    std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-    sub->setVal<CO_DEFTYPE_UNSIGNED16>((uint16_t)rpdo_mapped[idx][subidx]);
-    std::memcpy(&data, &sub->getVal<CO_DEFTYPE_UNSIGNED16>(), 2);
-  }
-  if (co_def == CO_DEFTYPE_INTEGER16)
-  {
-    std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-    sub->setVal<CO_DEFTYPE_INTEGER16>((int16_t)rpdo_mapped[idx][subidx]);
-    std::memcpy(&data, &sub->getVal<CO_DEFTYPE_INTEGER16>(), 2);
-  }
-  if (co_def == CO_DEFTYPE_UNSIGNED32)
-  {
-    std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-    sub->setVal<CO_DEFTYPE_UNSIGNED32>((uint32_t)rpdo_mapped[idx][subidx]);
-    std::memcpy(&data, &sub->getVal<CO_DEFTYPE_UNSIGNED32>(), 4);
-  }
-  if (co_def == CO_DEFTYPE_INTEGER32)
-  {
-    std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-    sub->setVal<CO_DEFTYPE_INTEGER32>((int32_t)rpdo_mapped[idx][subidx]);
-    std::memcpy(&data, &sub->getVal<CO_DEFTYPE_INTEGER32>(), 4);
+    case CO_DEFTYPE_BOOLEAN:
+    {
+      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+      sub->setVal<CO_DEFTYPE_BOOLEAN>((bool)rpdo_mapped[idx][subidx]);
+      std::memcpy(&data, &sub->getVal<CO_DEFTYPE_BOOLEAN>(), 1);
+      break;
+    }
+    case CO_DEFTYPE_UNSIGNED8:
+    {
+      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+      sub->setVal<CO_DEFTYPE_UNSIGNED8>((uint8_t)rpdo_mapped[idx][subidx]);
+      std::memcpy(&data, &sub->getVal<CO_DEFTYPE_UNSIGNED8>(), 1);
+      break;
+    }
+    case CO_DEFTYPE_INTEGER8:
+    {
+      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+      sub->setVal<CO_DEFTYPE_INTEGER8>((int8_t)rpdo_mapped[idx][subidx]);
+      std::memcpy(&data, &sub->getVal<CO_DEFTYPE_INTEGER8>(), 1);
+      break;
+    }
+    case CO_DEFTYPE_UNSIGNED16:
+    {
+      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+      sub->setVal<CO_DEFTYPE_UNSIGNED16>((uint16_t)rpdo_mapped[idx][subidx]);
+      std::memcpy(&data, &sub->getVal<CO_DEFTYPE_UNSIGNED16>(), 2);
+      break;
+    }
+    case CO_DEFTYPE_INTEGER16:
+    {
+      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+      sub->setVal<CO_DEFTYPE_INTEGER16>((int16_t)rpdo_mapped[idx][subidx]);
+      std::memcpy(&data, &sub->getVal<CO_DEFTYPE_INTEGER16>(), 2);
+      break;
+    }
+    case CO_DEFTYPE_UNSIGNED32:
+    {
+      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+      sub->setVal<CO_DEFTYPE_UNSIGNED32>((uint32_t)rpdo_mapped[idx][subidx]);
+      std::memcpy(&data, &sub->getVal<CO_DEFTYPE_UNSIGNED32>(), 4);
+      break;
+    }
+    case CO_DEFTYPE_INTEGER32:
+    {
+      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+      sub->setVal<CO_DEFTYPE_INTEGER32>((int32_t)rpdo_mapped[idx][subidx]);
+      std::memcpy(&data, &sub->getVal<CO_DEFTYPE_INTEGER32>(), 4);
+      break;
+    }
+    default:
+      std::cerr << "Unsupported CO_DEFTYPE: " << std::hex << (unsigned int)co_def << std::endl;
+      break;
   }
   COData codata = {idx, subidx, data};
 
@@ -215,29 +234,32 @@ std::future<bool> LelyDriverBridge::async_sdo_write(COData data)
   uint8_t co_def = (uint8_t)sub->getType();
   try
   {
-    if (co_def == CO_DEFTYPE_UNSIGNED8)
+    switch (co_def)
     {
-      this->submit_write<uint8_t>(data);
-    }
-    if (co_def == CO_DEFTYPE_INTEGER8)
-    {
-      this->submit_write<int8_t>(data);
-    }
-    if (co_def == CO_DEFTYPE_UNSIGNED16)
-    {
-      this->submit_write<uint16_t>(data);
-    }
-    if (co_def == CO_DEFTYPE_INTEGER16)
-    {
-      this->submit_write<int16_t>(data);
-    }
-    if (co_def == CO_DEFTYPE_UNSIGNED32)
-    {
-      this->submit_write<uint32_t>(data);
-    }
-    if (co_def == CO_DEFTYPE_INTEGER32)
-    {
-      this->submit_write<int32_t>(data);
+      case CO_DEFTYPE_BOOLEAN:
+        {this->submit_write<bool>(data);
+        break;}
+      case CO_DEFTYPE_UNSIGNED8:
+        {this->submit_write<uint8_t>(data);
+        break;}
+      case CO_DEFTYPE_INTEGER8:
+        {this->submit_write<int8_t>(data);
+        break;}
+      case CO_DEFTYPE_UNSIGNED16:
+        {this->submit_write<uint16_t>(data);
+        break;}
+      case CO_DEFTYPE_INTEGER16:
+        {this->submit_write<int16_t>(data);
+        break;}
+      case CO_DEFTYPE_UNSIGNED32:
+        {this->submit_write<uint32_t>(data);
+        break;}
+      case CO_DEFTYPE_INTEGER32:
+        {this->submit_write<int32_t>(data);
+        break;}
+      default:
+      std::cerr << "Unsupported CO_DEFTYPE: " << std::hex << (unsigned int)co_def << std::endl;
+      break;
     }
   }
   catch (lely::canopen::SdoError & e)
@@ -282,6 +304,10 @@ std::future<COData> LelyDriverBridge::async_sdo_read(COData data)
   uint8_t co_def = (uint8_t)sub->getType();
   try
   {
+    if (co_def == CO_DEFTYPE_BOOLEAN)
+    {
+      this->submit_read<bool>(data);
+    }
     if (co_def == CO_DEFTYPE_UNSIGNED8)
     {
       this->submit_read<uint8_t>(data);
@@ -334,73 +360,95 @@ void LelyDriverBridge::tpdo_transmit(COData data)
   lely::COSub * sub = this->dictionary_->find(data.index_, data.subindex_);
   if (sub == nullptr)
   {
-    // TODO(Dr. Denis): Add here static logger and output to debug!
-    // std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
-    //           << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
-    //           << " object does not exist" << std::endl;
+    // TODO(Dr. Denis): Add here static logger and output to warn/error!
+    std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
+              << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
+              << " object does not exist" << std::endl;
     return;
   }
   uint8_t co_def = (uint8_t)sub->getType();
   try
   {
-    if (co_def == CO_DEFTYPE_UNSIGNED8)
+    switch (co_def)
     {
-      uint8_t val;
-      std::memcpy(&val, &data.data_, sizeof(uint8_t));
-      tpdo_mapped[data.index_][data.subindex_] = val;
-      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-      sub->setVal<CO_DEFTYPE_UNSIGNED8>(val);
-    }
-    if (co_def == CO_DEFTYPE_INTEGER8)
-    {
-      int8_t val;
-      std::memcpy(&val, &data.data_, sizeof(int8_t));
-      tpdo_mapped[data.index_][data.subindex_] = val;
-      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-      sub->setVal<CO_DEFTYPE_INTEGER8>(val);
-    }
-    if (co_def == CO_DEFTYPE_UNSIGNED16)
-    {
-      uint16_t val;
-      std::memcpy(&val, &data.data_, sizeof(uint16_t));
-      tpdo_mapped[data.index_][data.subindex_] = val;
-      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-      sub->setVal<CO_DEFTYPE_UNSIGNED16>(val);
-    }
-    if (co_def == CO_DEFTYPE_INTEGER16)
-    {
-      int16_t val;
-      std::memcpy(&val, &data.data_, sizeof(int16_t));
-      tpdo_mapped[data.index_][data.subindex_] = val;
-      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-      sub->setVal<CO_DEFTYPE_INTEGER16>(val);
-    }
-    if (co_def == CO_DEFTYPE_UNSIGNED32)
-    {
-      uint32_t val;
-      std::memcpy(&val, &data.data_, sizeof(uint32_t));
-      tpdo_mapped[data.index_][data.subindex_] = val;
-      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-      sub->setVal<CO_DEFTYPE_UNSIGNED32>(val);
-    }
-    if (co_def == CO_DEFTYPE_INTEGER32)
-    {
-      int32_t val;
-      std::memcpy(&val, &data.data_, sizeof(int32_t));
-      tpdo_mapped[data.index_][data.subindex_] = val;
-      std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
-      sub->setVal<CO_DEFTYPE_INTEGER32>(val);
+      case CO_DEFTYPE_BOOLEAN:
+      {
+        bool val;
+        std::memcpy(&val, &data.data_, sizeof(bool));
+        tpdo_mapped[data.index_][data.subindex_] = val;
+        std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+        sub->setVal<CO_DEFTYPE_BOOLEAN>(val);
+        break;
+      }
+      case CO_DEFTYPE_UNSIGNED8:
+      {
+        uint8_t val;
+        std::memcpy(&val, &data.data_, sizeof(uint8_t));
+        tpdo_mapped[data.index_][data.subindex_] = val;
+        std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+        sub->setVal<CO_DEFTYPE_UNSIGNED8>(val);
+        break;
+      }
+      case CO_DEFTYPE_INTEGER8:
+      {
+        int8_t val;
+        std::memcpy(&val, &data.data_, sizeof(int8_t));
+        tpdo_mapped[data.index_][data.subindex_] = val;
+        std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+        sub->setVal<CO_DEFTYPE_INTEGER8>(val);
+        break;
+      }
+      case CO_DEFTYPE_UNSIGNED16:
+      {
+        uint16_t val;
+        std::memcpy(&val, &data.data_, sizeof(uint16_t));
+        tpdo_mapped[data.index_][data.subindex_] = val;
+        std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+        sub->setVal<CO_DEFTYPE_UNSIGNED16>(val);
+        break;
+      }
+      case CO_DEFTYPE_INTEGER16:
+      {
+        int16_t val;
+        std::memcpy(&val, &data.data_, sizeof(int16_t));
+        tpdo_mapped[data.index_][data.subindex_] = val;
+        std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+        sub->setVal<CO_DEFTYPE_INTEGER16>(val);
+        break;
+      }
+      case CO_DEFTYPE_UNSIGNED32:
+      {
+        uint32_t val;
+        std::memcpy(&val, &data.data_, sizeof(uint32_t));
+        tpdo_mapped[data.index_][data.subindex_] = val;
+        std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+        sub->setVal<CO_DEFTYPE_UNSIGNED32>(val);
+        break;
+      }
+      case CO_DEFTYPE_INTEGER32:
+      {
+        int32_t val;
+        std::memcpy(&val, &data.data_, sizeof(int32_t));
+        tpdo_mapped[data.index_][data.subindex_] = val;
+        std::scoped_lock<std::mutex> lck(this->dictionary_mutex_);
+        sub->setVal<CO_DEFTYPE_INTEGER32>(val);
+        break;
+      }
+      default:
+        std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
+              << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_ << " type=" << std::hex << (unsigned int)co_def << " data:" << (uint32_t)data.data_ << "TYPE NOT IMPLEMENTED - DATA WILL NOT BE WRTITTEN!!"<< std::endl;
+        break;
     }
     tpdo_mapped[data.index_][data.subindex_].WriteEvent();
     // std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
     //           << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
-    //           << " data:" << (uint32_t)data.data_ << std::endl;
+    //           << " type=" << std::hex << (unsigned int)co_def << " data:" << (uint32_t)data.data_ << std::endl;
   }
   catch (lely::canopen::SdoError & e)
   {
-    // std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
-    //           << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
-    //           << e.what() << std::endl;
+    std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
+              << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
+              << " type=" << std::hex << (unsigned int)co_def << e.what() << std::endl;
     return;
   }
 }

--- a/canopen_base_driver/src/lely_driver_bridge.cpp
+++ b/canopen_base_driver/src/lely_driver_bridge.cpp
@@ -360,7 +360,6 @@ void LelyDriverBridge::tpdo_transmit(COData data)
   lely::COSub * sub = this->dictionary_->find(data.index_, data.subindex_);
   if (sub == nullptr)
   {
-    // TODO(Dr. Denis): Add here static logger and output to warn/error!
     std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
               << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
               << " object does not exist" << std::endl;

--- a/canopen_base_driver/src/lely_driver_bridge.cpp
+++ b/canopen_base_driver/src/lely_driver_bridge.cpp
@@ -439,6 +439,7 @@ void LelyDriverBridge::tpdo_transmit(COData data)
         break;
     }
     tpdo_mapped[data.index_][data.subindex_].WriteEvent();
+    // Reduce the amount of output - this is not needed as it is on every write
     // std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
     //           << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
     //           << " type=" << std::hex << (unsigned int)co_def << " data:" << (uint32_t)data.data_ << std::endl;

--- a/canopen_base_driver/src/lely_driver_bridge.cpp
+++ b/canopen_base_driver/src/lely_driver_bridge.cpp
@@ -334,9 +334,10 @@ void LelyDriverBridge::tpdo_transmit(COData data)
   lely::COSub * sub = this->dictionary_->find(data.index_, data.subindex_);
   if (sub == nullptr)
   {
-    std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
-              << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
-              << " object does not exist" << std::endl;
+    // TODO(Dr. Denis): Add here static logger and output to debug!
+    // std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
+    //           << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
+    //           << " object does not exist" << std::endl;
     return;
   }
   uint8_t co_def = (uint8_t)sub->getType();
@@ -391,15 +392,15 @@ void LelyDriverBridge::tpdo_transmit(COData data)
       sub->setVal<CO_DEFTYPE_INTEGER32>(val);
     }
     tpdo_mapped[data.index_][data.subindex_].WriteEvent();
-    std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
-              << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
-              << " data:" << (uint32_t)data.data_ << std::endl;
+    // std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
+    //           << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
+    //           << " data:" << (uint32_t)data.data_ << std::endl;
   }
   catch (lely::canopen::SdoError & e)
   {
-    std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
-              << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
-              << e.what() << std::endl;
+    // std::cout << "async_pdo_write: id=" << (unsigned int)get_id() << " index=0x" << std::hex
+    //           << (unsigned int)data.index_ << " subindex=" << (unsigned int)data.subindex_
+    //           << e.what() << std::endl;
     return;
   }
 }

--- a/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver_impl.hpp
+++ b/canopen_proxy_driver/include/canopen_proxy_driver/node_interfaces/node_canopen_proxy_driver_impl.hpp
@@ -182,10 +182,10 @@ bool NodeCanopenProxyDriver<NODETYPE>::tpdo_transmit(ros2_canopen::COData & data
 {
   if (this->activated_.load())
   {
-    RCLCPP_INFO(
+    RCLCPP_DEBUG(
       this->node_->get_logger(), "Node ID 0x%X: Transmit PDO index %x, subindex %hhu, data %d",
       this->lely_driver_->get_id(), data.index_, data.subindex_,
-      data.data_);  // ToDo: Remove or make debug
+      data.data_);
     this->lely_driver_->tpdo_transmit(data);
     return true;
   }
@@ -197,7 +197,7 @@ void NodeCanopenProxyDriver<NODETYPE>::on_rpdo(ros2_canopen::COData d)
 {
   if (this->activated_.load())
   {
-    // RCLCPP_INFO(
+    // RCLCPP_DEBUG(
     //   this->node_->get_logger(), "Node ID 0x%X: Received PDO index %#04x, subindex %hhu, data
     //   %x", this->lely_driver_->get_id(), d.index_, d.subindex_, d.data_);
     auto message = canopen_interfaces::msg::COData();

--- a/canopen_proxy_driver/include/canopen_proxy_driver/proxy_driver.hpp
+++ b/canopen_proxy_driver/include/canopen_proxy_driver/proxy_driver.hpp
@@ -66,6 +66,11 @@ public:
   {
     node_canopen_proxy_driver_->register_rpdo_cb(rpdo_cb);
   }
+
+  void register_emcy_cb(std::function<void(COEmcy, uint8_t)> emcy_cb)
+  {
+    node_canopen_proxy_driver_->register_emcy_cb(emcy_cb);
+  }
 };
 }  // namespace ros2_canopen
 

--- a/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
@@ -162,9 +162,6 @@ struct WORos2ControlCoData : public Ros2ControlCOData
   // needed internally for write-only data
   double one_shot;
 
-  // Create the casters
-  std::map<std::string, std::function<void()>> copiers;
-
   bool write_command()
   {
     bool ret_val;

--- a/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
@@ -240,13 +240,25 @@ struct Ros2ControlEmcyData
   {
     original_emcy = e;
 
-    error_code = static_cast<double>(e.eec);
-    error_register = static_cast<double>(e.er);
-    manufacturer_error_code1 = static_cast<double>(e.msef[0]);
-    manufacturer_error_code2 = static_cast<double>(e.msef[1]);
-    manufacturer_error_code3 = static_cast<double>(e.msef[2]);
-    manufacturer_error_code4 = static_cast<double>(e.msef[3]);
-    manufacturer_error_code5 = static_cast<double>(e.msef[4]);
+    uint16_t eec_data;
+    std::memcpy(&eec_data, &e.eec, sizeof(uint16_t));
+    error_code = static_cast<double>(eec_data);
+
+    uint8_t er_data;
+    std::memcpy(&er_data, &e.er, sizeof(uint8_t));
+    error_register = static_cast<double>(er_data);
+
+    uint16_t msef_data;
+    std::memcpy(&msef_data, &e.msef[0], sizeof(uint16_t));
+    manufacturer_error_code1 = static_cast<double>(msef_data);
+    std::memcpy(&msef_data, &e.msef[1], sizeof(uint16_t));
+    manufacturer_error_code2 = static_cast<double>(msef_data);
+    std::memcpy(&msef_data, &e.msef[2], sizeof(uint16_t));
+    manufacturer_error_code3 = static_cast<double>(msef_data);
+    std::memcpy(&msef_data, &e.msef[3], sizeof(uint16_t));
+    manufacturer_error_code4 = static_cast<double>(msef_data);
+    std::memcpy(&msef_data, &e.msef[4], sizeof(uint16_t));
+    manufacturer_error_code5 = static_cast<double>(msef_data);
   }
 
   double error_code;             // read-only
@@ -353,7 +365,7 @@ struct CanopenNodeData
       // if it is not, add it to the map
       rpdo_raw_data_map.emplace(index_pair, d.data_);
     }
-    // TODO(Dr.Denis): kept for backward compatibility - should b removed
+    // TODO(Dr.Denis): kept for backward compatibility - should be removed
     // check if the index pair is already in the map
     if (rpdo_data_map.find(index_pair) != rpdo_data_map.end())
     {

--- a/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
@@ -24,9 +24,12 @@
 #ifndef CANOPEN_ROS2_CONTROL__CANOPEN_SYSTEM_HPP_
 #define CANOPEN_ROS2_CONTROL__CANOPEN_SYSTEM_HPP_
 
+#include <functional>
+#include <limits>
 #include <queue>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "canopen_core/device_container.hpp"
 #include "canopen_proxy_driver/proxy_driver.hpp"
@@ -41,6 +44,26 @@
 
 namespace canopen_ros2_control
 {
+template<typename TargetType, typename SourceType>
+auto makeMemcpyCaster(const SourceType& source)
+{
+    return [&source]() -> TargetType {
+        TargetType target;
+        std::memcpy(&target, &source, sizeof(TargetType));
+        return target;
+    };
+}
+
+const std::vector<std::string> SUPPORTED_TYPES = {
+  "bool",
+  "int8_t",
+  "uint8_t",
+  "int16_t",
+  "uint16_t",
+  "int32_t",
+  "uint32_t"
+};
+
 // needed auxiliary struct for ros2 control double registration
 struct Ros2ControlCOData
 {
@@ -51,17 +74,84 @@ struct Ros2ControlCOData
   double index;     // cast to uint16_t
   double subindex;  // cast to uint8_t
   double data;      // cast to uint32_t
+
+  std::string co_type = "int32_t";  // use int32_t as default
+
+  void set_co_data_type(const std::string & type)
+  {
+    if (type.empty() || std::find(SUPPORTED_TYPES.begin(), SUPPORTED_TYPES.end(), type) != SUPPORTED_TYPES.end())
+    {
+      co_type = type;
+    }
+    else
+    {
+      RCLCPP_WARN(rclcpp::get_logger("rclcpp"), "Type '%s' empty or not yet supported. Using 'int32_t' as default to cast directly to double. This might cause errornous data! Please contribute or by maintainers a cookie and hope they implement it for you!", type.c_str());
+      co_type = "int32_t";
+    }
+  }
 };
+
+
 
 struct RORos2ControlCOData : public Ros2ControlCOData
 {
   void set_data(ros2_canopen::COData d)
   {
     original_data = d;
+  }
 
+  void prepare_data()
+  {
     index = static_cast<double>(original_data.index_);
     subindex = static_cast<double>(original_data.subindex_);
-    data = static_cast<double>(original_data.data_);
+
+    if (co_type == "bool")
+    {
+      bool bool_data;
+      std::memcpy(&bool_data, &original_data.data_, sizeof(bool));
+      data = static_cast<double>(bool_data);
+    }
+    else if (co_type == "int8_t")
+    {
+      int8_t int8_data;
+      std::memcpy(&int8_data, &original_data.data_, sizeof(int8_t));
+      data = static_cast<double>(int8_data);
+    }
+    else if (co_type == "uint8_t")
+    {
+      uint8_t uint8_data;
+      std::memcpy(&uint8_data, &original_data.data_, sizeof(uint8_t));
+      data = static_cast<double>(uint8_data);
+    }
+    else if (co_type == "int16_t")
+    {
+      int16_t int16_data;
+      std::memcpy(&int16_data, &original_data.data_, sizeof(int16_t));
+      data = static_cast<double>(int16_data);
+    }
+    else if (co_type == "uint16_t")
+    {
+      uint16_t uint16_data;
+      std::memcpy(&uint16_data, &original_data.data_, sizeof(uint16_t));
+      data = static_cast<double>(uint16_data);
+    }
+    else if (co_type == "int32_t")
+    {
+      int32_t int32_data;
+      std::memcpy(&int32_data, &original_data.data_, sizeof(int32_t));
+      data = static_cast<double>(int32_data);
+    }
+    else if (co_type == "uint32_t")
+    {
+      uint32_t uint32_data;
+      std::memcpy(&uint32_data, &original_data.data_, sizeof(uint32_t));
+      data = static_cast<double>(uint32_data);
+    }
+    else
+    {
+      RCLCPP_WARN(rclcpp::get_logger("rclcpp"), "Type '%s' not yet supported. Trying to cast directly to double. This might cause errornous data! Please contribute or by maintainers a cookie and hope they implement it for you!", co_type.c_str());
+      data = static_cast<double>(original_data.data_);
+    }
   }
 };
 
@@ -71,6 +161,9 @@ struct WORos2ControlCoData : public Ros2ControlCOData
 
   // needed internally for write-only data
   double one_shot;
+
+  // Create the casters
+  std::map<std::string, std::function<void()>> copiers;
 
   bool write_command()
   {
@@ -86,9 +179,87 @@ struct WORos2ControlCoData : public Ros2ControlCOData
   {
     original_data.index_ = static_cast<uint16_t>(index);
     original_data.subindex_ = static_cast<uint8_t>(subindex);
-    original_data.data_ = static_cast<uint32_t>(data);
+
+    if (co_type == "bool")
+    {
+      bool bool_data = static_cast<bool>(data);
+      std::memcpy(&original_data.data_, &bool_data, sizeof(bool));
+    }
+    else if (co_type == "int8_t")
+    {
+      int8_t int8_data = static_cast<int8_t>(data);
+      std::memcpy(&original_data.data_, &int8_data, sizeof(int8_t));
+    }
+    else if (co_type == "uint8_t")
+    {
+      uint8_t uint8_data = static_cast<uint8_t>(data);
+      std::memcpy(&original_data.data_, &uint8_data, sizeof(uint8_t));
+    }
+    else if (co_type == "int16_t")
+    {
+      int16_t int16_data = static_cast<int16_t>(data);
+      std::memcpy(&original_data.data_, &int16_data, sizeof(int16_t));
+    }
+    else if (co_type == "uint16_t")
+    {
+      uint16_t uint16_data = static_cast<uint16_t>(data);
+      std::memcpy(&original_data.data_, &uint16_data, sizeof(uint16_t));
+    }
+    else if (co_type == "int32_t")
+    {
+      int32_t int32_data = static_cast<int32_t>(data);
+      std::memcpy(&original_data.data_, &int32_data, sizeof(int32_t));
+    }
+    else if (co_type == "uint32_t")
+    {
+      uint32_t uint32_data = static_cast<uint32_t>(data);
+      std::memcpy(&original_data.data_, &uint32_data, sizeof(uint32_t));
+    }
+    else
+    {
+      RCLCPP_WARN(rclcpp::get_logger("rclcpp"), "Type '%s' not yet supported. Trying to cast directly to uint32_t. This might cause errornous data! Please contribute or by maintainers a cookie and hope they implement it for you!", co_type.c_str());
+      original_data.data_ = static_cast<uint32_t>(data);
+    }
   }
 };
+
+struct Ros2ControlEmcyData
+{
+  Ros2ControlEmcyData()
+  : error_code(0),
+    error_register(0),
+    manufacturer_error_code1(0),
+    manufacturer_error_code2(0),
+    manufacturer_error_code3(0),
+    manufacturer_error_code4(0),
+    manufacturer_error_code5(0)
+  {
+  }
+
+  void set_emcy(ros2_canopen::COEmcy e)
+  {
+    original_emcy = e;
+
+    error_code = static_cast<double>(e.eec);
+    error_register = static_cast<double>(e.er);
+    manufacturer_error_code1 = static_cast<double>(e.msef[0]);
+    manufacturer_error_code2 = static_cast<double>(e.msef[1]);
+    manufacturer_error_code3 = static_cast<double>(e.msef[2]);
+    manufacturer_error_code4 = static_cast<double>(e.msef[3]);
+    manufacturer_error_code5 = static_cast<double>(e.msef[4]);
+  }
+
+  double error_code;             // read-only
+  double error_register;         // read-only
+  double manufacturer_error_code1;  // read-only
+  double manufacturer_error_code2;  // read-only
+  double manufacturer_error_code3;  // read-only
+  double manufacturer_error_code4;  // read-only
+  double manufacturer_error_code5;  // read-only
+
+  ros2_canopen::COEmcy original_emcy;  // read-only
+};
+
 struct Ros2ControlNmtState
 {
   Ros2ControlNmtState()
@@ -150,32 +321,64 @@ struct pair_hash
 struct CanopenNodeData
 {
   Ros2ControlNmtState nmt_state;  // read-write
+  //TODO(Dr.Denis): we should have have a map that we can assign or somehow connect it to definition on interfaces - currently is the code not optimized, there are quite some duplications
   RORos2ControlCOData rpdo_data;  // read-only
   WORos2ControlCoData tpdo_data;  // write-only
+
+  Ros2ControlEmcyData emcy_data;  // read-only
 
   WORos2ControlCoData rsdo;  // write-only
   WORos2ControlCoData wsdo;  // write-only
 
   using PDO_INDICES = std::pair<uint16_t, uint8_t>;  // Index, Subindex
-  std::unordered_map<PDO_INDICES, double, pair_hash> rpdo_data_map;
+  std::unordered_map<PDO_INDICES, double, pair_hash> rpdo_data_map;  // kept for backward compoatibility - should b removed
+  std::unordered_map<PDO_INDICES, uint32_t, pair_hash> rpdo_raw_data_map;
 
   // Push data to the queue - FIFO
   void set_rpdo_data(ros2_canopen::COData d)
   {
     rpdo_data.set_data(d);
+    rpdo_data.prepare_data();
 
     PDO_INDICES index_pair(d.index_, d.subindex_);
 
     // check if the index pair is already in the map
+    if (rpdo_raw_data_map.find(index_pair) != rpdo_raw_data_map.end())
+    {
+      // if it is, update the value
+      rpdo_raw_data_map.at(index_pair) = d.data_;
+    }
+    else
+    {
+      // if it is not, add it to the map
+      rpdo_raw_data_map.emplace(index_pair, d.data_);
+    }
+    // TODO(Dr.Denis): kept for backward compatibility - should b removed
+    // check if the index pair is already in the map
     if (rpdo_data_map.find(index_pair) != rpdo_data_map.end())
     {
       // if it is, update the value
-      rpdo_data_map[index_pair] = rpdo_data.data;
+      rpdo_data_map.at(index_pair) = rpdo_data.data;
     }
     else
     {
       // if it is not, add it to the map
       rpdo_data_map.emplace(index_pair, rpdo_data.data);
+    }
+  }
+
+  uint32_t get_rpdo_raw_data(uint16_t index, uint8_t subindex)
+  {
+    PDO_INDICES index_pair(index, subindex);
+    if (rpdo_raw_data_map.find(index_pair) != rpdo_raw_data_map.end())
+    {
+      return rpdo_raw_data_map.at(index_pair);
+    }
+    else
+    {
+      // Log error
+      // RCLCPP_WARN(kLogger, "The index pair (%u, %u) is not in the map", index, subindex);
+      return std::numeric_limits<uint32_t>::quiet_NaN();
     }
   }
 
@@ -191,7 +394,7 @@ struct CanopenNodeData
     {
       // // Log error
       // RCLCPP_WARN(kLogger, "The index pair (%u, %u) is not in the map", index, subindex);
-      return 0;
+      return std::numeric_limits<double>::quiet_NaN();
     }
   }
 };

--- a/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
@@ -44,6 +44,8 @@ namespace canopen_ros2_control
 // needed auxiliary struct for ros2 control double registration
 struct Ros2ControlCOData
 {
+  // TODO(Dr.Denis): rename original data to canopen data
+  // Soon we can drop this as ros2_control support variants - we have to add support for all this types
   ros2_canopen::COData original_data;
 
   double index;     // cast to uint16_t

--- a/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
@@ -330,7 +330,6 @@ struct pair_hash
 struct CanopenNodeData
 {
   Ros2ControlNmtState nmt_state;  // read-write
-  //TODO(Dr.Denis): we should have have a map that we can assign or somehow connect it to definition on interfaces - currently is the code not optimized, there are quite some duplications
   RORos2ControlCOData rpdo_data;  // read-only
   WORos2ControlCoData tpdo_data;  // write-only
 

--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -131,27 +131,35 @@ void CanopenSystem::initDeviceContainer()
   device_container_->init(
     info_.hardware_parameters["can_interface_name"], info_.hardware_parameters["master_config"],
     info_.hardware_parameters["bus_config"], tmp_master_bin);
-  auto drivers = device_container_->get_registered_drivers();
   RCLCPP_INFO(kLogger, "Number of registered drivers: '%zu'", device_container_->count_drivers());
   // TODO interate here also over Node_IDs (as below)
-  for (auto it = drivers.begin(); it != drivers.end(); it++)
+  for (const auto & [node_id, driver] : device_container_->get_registered_drivers())
   {
-    auto proxy_driver = std::static_pointer_cast<ros2_canopen::ProxyDriver>(it->second);
+    auto proxy_driver = std::static_pointer_cast<ros2_canopen::ProxyDriver>(driver);
+    // initialize canopen data it not existing
+    if (canopen_data_.find(node_id) == canopen_data_.end())
+    {
+      canopen_data_[node_id] = CanopenNodeData();
+    }
 
     auto nmt_state_cb = [&](canopen::NmtState nmt_state, uint8_t id)
     { canopen_data_[id].nmt_state.set_state(nmt_state); };
     // register callback
     proxy_driver->register_nmt_state_cb(nmt_state_cb);
 
-    // The id here refer to the node id
     auto rpdo_cb = [&](ros2_canopen::COData data, uint8_t id)
     { canopen_data_[id].set_rpdo_data(data); };
     // register callback
     proxy_driver->register_rpdo_cb(rpdo_cb);
 
+    auto emcy_cb = [&](ros2_canopen::COEmcy data, uint8_t id)
+    { canopen_data_[id].emcy_data.set_emcy(data); };
+    // register callback
+    proxy_driver->register_emcy_cb(emcy_cb);
+
     RCLCPP_INFO(
       kLogger, "\nRegistered driver:\n    name: '%s'\n    node_id: '0x%X'",  //
-      it->second->get_node_base_interface()->get_name(), it->first);
+      driver->get_node_base_interface()->get_name(), node_id);
   }
 
   RCLCPP_INFO(device_container_->get_logger(), "Initialisation successful.");
@@ -183,6 +191,21 @@ std::vector<hardware_interface::StateInterface> CanopenSystem::export_state_inte
 
     state_interfaces.emplace_back(hardware_interface::StateInterface(
       info_.joints[i].name, "nmt/state", &canopen_data_[node_id].nmt_state.state));
+
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[i].name, "emcy/error_code", &canopen_data_[node_id].emcy_data.error_code));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[i].name, "emcy/error_register", &canopen_data_[node_id].emcy_data.error_register));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[i].name, "emcy/manufacturer_error_code1", &canopen_data_[node_id].emcy_data.manufacturer_error_code1));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[i].name, "emcy/manufacturer_error_code2", &canopen_data_[node_id].emcy_data.manufacturer_error_code2));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[i].name, "emcy/manufacturer_error_code3", &canopen_data_[node_id].emcy_data.manufacturer_error_code3));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[i].name, "emcy/manufacturer_error_code4", &canopen_data_[node_id].emcy_data.manufacturer_error_code4));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[i].name, "emcy/manufacturer_error_code5", &canopen_data_[node_id].emcy_data.manufacturer_error_code5));
   }
 
   return state_interfaces;
@@ -257,6 +280,21 @@ hardware_interface::return_type CanopenSystem::read(
   // double stuff = canopen_data_[node_id].get_rpdo_data(0x211D, 0x00);
   // RCLCPP_INFO(kLogger, "NodeID: 0x%X; Stuff: %f", node_id, stuff);
 
+  // TODO(Dr. Deni): don't forget to call `prepare_data()` after those are got from RPDO.
+
+  for (const auto & [node_id, canopen_data] : canopen_data_)
+  {
+    if (canopen_data.emcy_data.error_code != 0)
+    {
+      RCLCPP_ERROR(
+        kLogger, "NodeID: 0x%X; Error code: %u; Error register: %u; Manufacturer error code: [%u, %u, %u, %u, %u];",
+        node_id, canopen_data.emcy_data.original_emcy.eec, canopen_data.emcy_data.original_emcy.er,
+        canopen_data.emcy_data.original_emcy.msef[0], canopen_data.emcy_data.original_emcy.msef[1],
+        canopen_data.emcy_data.original_emcy.msef[2], canopen_data.emcy_data.original_emcy.msef[3],
+        canopen_data.emcy_data.original_emcy.msef[4]);
+    }
+  }
+
   return hardware_interface::return_type::OK;
 }
 
@@ -314,7 +352,6 @@ hardware_interface::return_type CanopenSystem::write(
       {
         std::cerr << e.what() << '\n';
       }
-      
     }
   }
 

--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -120,6 +120,8 @@ void CanopenSystem::spin()
   RCLCPP_INFO(kLogger, "Exiting spin thread...");
 }
 
+// TODO(Dr. Denis): this should be actually `on_configure` method and not a new thread. Why is this a separete thread?
+// Maybe because it could block, but this shouldn't be an issue, if mutliple hardware is used then `async` HW should be set for this!
 void CanopenSystem::initDeviceContainer()
 {
   std::string tmp_master_bin = (info_.hardware_parameters["master_bin"] == "\"\"")
@@ -250,10 +252,10 @@ hardware_interface::return_type CanopenSystem::read(
 
   // rpdo has a queue of messages, we read the latest one
 
-  uint8_t node_id = 0x1E;
+  // uint8_t node_id = 0x1E;
 
-  double stuff = canopen_data_[node_id].get_rpdo_data(0x211D, 0x00);
-  RCLCPP_INFO(kLogger, "NodeID: 0x%X; Stuff: %f", node_id, stuff);
+  // double stuff = canopen_data_[node_id].get_rpdo_data(0x211D, 0x00);
+  // RCLCPP_INFO(kLogger, "NodeID: 0x%X; Stuff: %f", node_id, stuff);
 
   return hardware_interface::return_type::OK;
 }
@@ -263,11 +265,6 @@ hardware_interface::return_type CanopenSystem::write(
 {
   // TODO(anyone): write robot's commands'
   auto drivers = device_container_->get_registered_drivers();
-
-  for (const auto& entry : canopen_data_)
-  {
-    RCLCPP_INFO(kLogger, "Key in canopen_data_: 0x%X", entry.first);
-  }
 
   for (auto it = canopen_data_.begin(); it != canopen_data_.end(); ++it)
   {
@@ -291,19 +288,19 @@ hardware_interface::return_type CanopenSystem::write(
       it->second.nmt_state.start_fbk = static_cast<double>(proxy_driver->start_node_nmt_command());
     }
 
-    canopen_ros2_control::WORos2ControlCoData data;
-    data.index = 0x2110;
-    data.subindex = 0x00;
-    data.data = int16_t(123);
-    data.prepare_data();
-    RCLCPP_INFO(kLogger, "This is a debug message in HW-write().....");
-    RCLCPP_INFO(kLogger, "NodeID: 0x%X; Index: 0x%X; Subindex: 0x%X; Data: %u",
-      it->first,
-      data.original_data.index_,
-      data.original_data.subindex_,
-      data.original_data.data_);
-    RCLCPP_INFO(kLogger, "--- END of the debug message in HW-write()");
-    proxy_driver->tpdo_transmit(data.original_data);
+    // canopen_ros2_control::WORos2ControlCoData data;
+    // data.index = 0x2110;
+    // data.subindex = 0x00;
+    // data.data = int16_t(123);
+    // data.prepare_data();
+    // RCLCPP_INFO(kLogger, "This is a debug message in HW-write().....");
+    // RCLCPP_INFO(kLogger, "NodeID: 0x%X; Index: 0x%X; Subindex: 0x%X; Data: %u",
+    //   it->first,
+    //   data.original_data.index_,
+    //   data.original_data.subindex_,
+    //   data.original_data.data_);
+    // RCLCPP_INFO(kLogger, "--- END of the debug message in HW-write()");
+    // proxy_driver->tpdo_transmit(data.original_data);
 
     // tpdo data one shot mechanism
     if (it->second.tpdo_data.write_command())

--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -287,7 +287,7 @@ hardware_interface::return_type CanopenSystem::read(
     if (canopen_data.emcy_data.error_code != 0)
     {
       RCLCPP_ERROR(
-        kLogger, "NodeID: 0x%X; Error code: %u; Error register: %u; Manufacturer error code: [%u, %u, %u, %u, %u];",
+        kLogger, "NodeID: 0x%X; Error code: %X; Error register: %X; Manufacturer error code: [%X, %X, %X, %X, %X];",
         node_id, canopen_data.emcy_data.original_emcy.eec, canopen_data.emcy_data.original_emcy.er,
         canopen_data.emcy_data.original_emcy.msef[0], canopen_data.emcy_data.original_emcy.msef[1],
         canopen_data.emcy_data.original_emcy.msef[2], canopen_data.emcy_data.original_emcy.msef[3],
@@ -295,7 +295,7 @@ hardware_interface::return_type CanopenSystem::read(
     }
   }
 
-  return hardware_interface::return_type::OK;
+  return hardware_interface::return_type::ERROR;
 }
 
 hardware_interface::return_type CanopenSystem::write(
@@ -308,7 +308,7 @@ hardware_interface::return_type CanopenSystem::write(
   {
     if (drivers.find(it->first) == drivers.end())
     {
-      // this is expeced for NodeID 0x00 - why do we have it at all? 
+      // this is expeced for NodeID 0x00 - why do we have it at all?
       RCLCPP_DEBUG(kLogger, "Driver for NodeID 0x%X not found. Skipping...", it->first);
       continue;
     }

--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -272,13 +272,6 @@ hardware_interface::return_type CanopenSystem::read(
 
   // rpdo has a queue of messages, we read the latest one
 
-  // uint8_t node_id = 0x1E;
-
-  // double stuff = canopen_data_[node_id].get_rpdo_data(0x211D, 0x00);
-  // RCLCPP_INFO(kLogger, "NodeID: 0x%X; Stuff: %f", node_id, stuff);
-
-  // TODO(Dr. Deni): don't forget to call `prepare_data()` after those are got from RPDO.
-
   for (const auto & [node_id, canopen_data] : canopen_data_)
   {
     if (canopen_data.emcy_data.error_code != 0)

--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -120,8 +120,6 @@ void CanopenSystem::spin()
   RCLCPP_INFO(kLogger, "Exiting spin thread...");
 }
 
-// TODO(Dr. Denis): this should be actually `on_configure` method and not a new thread. Why is this a separete thread?
-// Maybe because it could block, but this shouldn't be an issue, if mutliple hardware is used then `async` HW should be set for this!
 void CanopenSystem::initDeviceContainer()
 {
   std::string tmp_master_bin = (info_.hardware_parameters["master_bin"] == "\"\"")

--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -130,7 +130,6 @@ void CanopenSystem::initDeviceContainer()
     info_.hardware_parameters["can_interface_name"], info_.hardware_parameters["master_config"],
     info_.hardware_parameters["bus_config"], tmp_master_bin);
   RCLCPP_INFO(kLogger, "Number of registered drivers: '%zu'", device_container_->count_drivers());
-  // TODO interate here also over Node_IDs (as below)
   for (const auto & [node_id, driver] : device_container_->get_registered_drivers())
   {
     auto proxy_driver = std::static_pointer_cast<ros2_canopen::ProxyDriver>(driver);

--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -316,20 +316,6 @@ hardware_interface::return_type CanopenSystem::write(
       it->second.nmt_state.start_fbk = static_cast<double>(proxy_driver->start_node_nmt_command());
     }
 
-    // canopen_ros2_control::WORos2ControlCoData data;
-    // data.index = 0x2110;
-    // data.subindex = 0x00;
-    // data.data = int16_t(123);
-    // data.prepare_data();
-    // RCLCPP_INFO(kLogger, "This is a debug message in HW-write().....");
-    // RCLCPP_INFO(kLogger, "NodeID: 0x%X; Index: 0x%X; Subindex: 0x%X; Data: %u",
-    //   it->first,
-    //   data.original_data.index_,
-    //   data.original_data.subindex_,
-    //   data.original_data.data_);
-    // RCLCPP_INFO(kLogger, "--- END of the debug message in HW-write()");
-    // proxy_driver->tpdo_transmit(data.original_data);
-
     // tpdo data one shot mechanism
     if (it->second.tpdo_data.write_command())
     {

--- a/canopen_ros2_control/src/cia402_system.cpp
+++ b/canopen_ros2_control/src/cia402_system.cpp
@@ -38,9 +38,10 @@ Cia402System::Cia402System() : CanopenSystem() {}
 hardware_interface::CallbackReturn Cia402System::on_init(
   const hardware_interface::HardwareInfo & info)
 {
-  if (CanopenSystem::on_init(info) != CallbackReturn::SUCCESS)
+  auto ret_val = CanopenSystem::on_init(info);
+  if (ret_val != hardware_interface::CallbackReturn::SUCCESS)
   {
-    return CallbackReturn::ERROR;
+    return ret_val;
   }
 
   return CallbackReturn::SUCCESS;


### PR DESCRIPTION
Extended Lely bridge to support handling of more data-types.

Also properly handling Emcy in the ros2_control and corrected mapping regarding data-types to be correct. Still using "double" as main type.
