### PR TITLE
Fix deprecated hardware_interface API

### DIFF
--- a/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
@@ -424,7 +424,7 @@ public:
   ~CanopenSystem();
   CANOPEN_ROS2_CONTROL__VISIBILITY_PUBLIC
   hardware_interface::CallbackReturn on_init(
-    const hardware_interface::HardwareInfo & info) override;
+    const hardware_interface::HardwareComponentInterfaceParams & params) override;
 
   CANOPEN_ROS2_CONTROL__VISIBILITY_PUBLIC
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override;

--- a/canopen_ros2_control/include/canopen_ros2_control/cia402_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/cia402_system.hpp
@@ -88,7 +88,7 @@ public:
   CANOPEN_ROS2_CONTROL__VISIBILITY_PUBLIC
   ~Cia402System() = default;
   CANOPEN_ROS2_CONTROL__VISIBILITY_PUBLIC
-  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo & info);
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams & params);
 
   CANOPEN_ROS2_CONTROL__VISIBILITY_PUBLIC
   hardware_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state);

--- a/canopen_ros2_control/include/canopen_ros2_control/robot_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/robot_system.hpp
@@ -53,7 +53,7 @@ public:
    */
   CANOPEN_ROS2_CONTROL__VISIBILITY_PUBLIC
   hardware_interface::CallbackReturn on_init(
-    const hardware_interface::HardwareInfo & info) override;
+    const hardware_interface::HardwareComponentInterfaceParams & params) override;
 
   /**
    * @brief Configure the hardware interface

--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -58,9 +58,9 @@ void CanopenSystem::clean()
 CanopenSystem::~CanopenSystem() { clean(); }
 
 hardware_interface::CallbackReturn CanopenSystem::on_init(
-  const hardware_interface::HardwareInfo & info)
+  const hardware_interface::HardwareComponentInterfaceParams & params)
 {
-  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
+  if (hardware_interface::SystemInterface::on_init(params) != CallbackReturn::SUCCESS)
   {
     return CallbackReturn::ERROR;
   }

--- a/canopen_ros2_control/src/cia402_system.cpp
+++ b/canopen_ros2_control/src/cia402_system.cpp
@@ -36,9 +36,9 @@ namespace canopen_ros2_control
 Cia402System::Cia402System() : CanopenSystem() {}
 
 hardware_interface::CallbackReturn Cia402System::on_init(
-  const hardware_interface::HardwareInfo & info)
+  const hardware_interface::HardwareComponentInterfaceParams & params)
 {
-  auto ret_val = CanopenSystem::on_init(info);
+  auto ret_val = CanopenSystem::on_init(params);
   if (ret_val != hardware_interface::CallbackReturn::SUCCESS)
   {
     return ret_val;

--- a/canopen_ros2_control/src/robot_system.cpp
+++ b/canopen_ros2_control/src/robot_system.cpp
@@ -22,9 +22,9 @@ using namespace canopen_ros2_control;
 // auto robot_system_logger = rclcpp::get_logger("robot_system_interface");
 
 hardware_interface::CallbackReturn RobotSystem::on_init(
-  const hardware_interface::HardwareInfo & info)
+  const hardware_interface::HardwareComponentInterfaceParams & params)
 {
-  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
+  if (hardware_interface::SystemInterface::on_init(params) != CallbackReturn::SUCCESS)
   {
     return CallbackReturn::ERROR;
   }


### PR DESCRIPTION
See https://github.com/ros-controls/ros2_control/pull/2323
needed for https://github.com/ros-controls/ros2_control/pull/2589

Please release it to kilted and rolling, thanks :)
Note: This API is not available on humble.