### PR TITLE
Fix hardcoded absolute paths in bus.yml and master.dcf

### DIFF
--- a/lely_core_libraries/cmake/lely_core_libraries-extras.cmake
+++ b/lely_core_libraries/cmake/lely_core_libraries-extras.cmake
@@ -31,9 +31,10 @@ macro(
 
     add_custom_command(
         TARGET ${TARGET} POST_BUILD
-        COMMAND sed 's|@BUS_CONFIG_PATH@|${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/config/${TARGET}|g'
+        COMMAND sed 's|@BUS_CONFIG_PATH@|.|g'
             ${CMAKE_CURRENT_SOURCE_DIR}/config/${TARGET}/bus.yml > ${CMAKE_BINARY_DIR}/config/${TARGET}/bus.yml
         COMMAND dcfgen -v -d ${CMAKE_BINARY_DIR}/config/${TARGET}/ -rS ${CMAKE_BINARY_DIR}/config/${TARGET}/bus.yml
+        COMMAND sed -i 's|UploadFile=${CMAKE_BINARY_DIR}/config/${TARGET}/|UploadFile=|g' ${CMAKE_BINARY_DIR}/config/${TARGET}/master.dcf
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/config/${TARGET}/
     )
 
@@ -69,9 +70,10 @@ macro(
     add_custom_command(
         TARGET ${TARGET} POST_BUILD
         COMMAND cogen --input-file ${CMAKE_CURRENT_SOURCE_DIR}/config/${TARGET}/bus.yml --output-file ${CMAKE_BINARY_DIR}/config/${TARGET}/preprocessed_bus.yml
-        COMMAND sed 's|@BUS_CONFIG_PATH@|${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/config/${TARGET}|g'
+        COMMAND sed 's|@BUS_CONFIG_PATH@|.|g'
             ${CMAKE_BINARY_DIR}/config/${TARGET}/preprocessed_bus.yml > ${CMAKE_BINARY_DIR}/config/${TARGET}/bus.yml
         COMMAND dcfgen -v -d ${CMAKE_BINARY_DIR}/config/${TARGET}/ -rS ${CMAKE_BINARY_DIR}/config/${TARGET}/bus.yml
+        COMMAND sed -i 's|UploadFile=${CMAKE_BINARY_DIR}/config/${TARGET}/|UploadFile=|g' ${CMAKE_BINARY_DIR}/config/${TARGET}/master.dcf
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/config/${TARGET}/
     )
 


### PR DESCRIPTION
Before:
```bash
$ grep dcf_path install/my_pkg/share/my_pkg/config/my_motor/bus.yml
dcf_path: '/home/user/ros_ws/install/my_pkg/share/my_pkg/config/my_motor'
$ grep UploadFile install/my_pkg/share/my_pkg/config/my_motor/master.dcf
UploadFile=/home/user/ros_ws/install/my_pkg/share/my_pkg/config/my_motor/drive_left.bin
```
This means my install space is not portable as it contains hardcoded paths. So I cannot just put it on another machine/robot and source it.

After:
```bash
$ grep dcf_path install/my_pkg/share/my_pkg/config/my_motor/bus.yml
dcf_path: '.'
$ grep UploadFile install/my_pkg/share/my_pkg/config/my_motor/master.dcf
UploadFile=./drive_left.bin
```

Now my install space _is_ portable and functional.