### PR TITLE
CMake: Harden yaml-cpp usage

### DIFF
--- a/canopen_core/CMakeLists.txt
+++ b/canopen_core/CMakeLists.txt
@@ -57,6 +57,8 @@ ament_target_dependencies(node_canopen_driver
   rclcpp
   rclcpp_lifecycle
   lely_core_libraries
+  yaml_cpp_vendor
+  yaml-cpp
   canopen_interfaces
   Boost
 )


### PR DESCRIPTION
After `find_package`'ing `yaml_cpp_vendor`, explicitly find also `yaml-cpp`, and link the correct target.