### PR TITLE
Cleanup Boost dependencies

### DIFF
--- a/canopen_402_driver/package.xml
+++ b/canopen_402_driver/package.xml
@@ -9,7 +9,10 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <depend>boost</depend>
+  <build_depend>boost</build_depend>
+
+  <build_export_depend>boost</build_export_depend>
+
   <depend>canopen_base_driver</depend>
   <depend>canopen_core</depend>
   <depend>canopen_interfaces</depend>

--- a/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/lely_driver_bridge.hpp
@@ -37,10 +37,6 @@
 #include <thread>
 #include <vector>
 
-#include <boost/lockfree/queue.hpp>
-#include <boost/optional.hpp>
-#include <boost/thread.hpp>
-
 #include "canopen_core/exchange.hpp"
 
 using namespace std::chrono_literals;

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -240,7 +240,8 @@ template <class NODETYPE>
 void NodeCanopenBaseDriver<NODETYPE>::deactivate(bool called_from_base)
 {
   nmt_state_publisher_thread_.join();
-  if (poll_timer_) {
+  if (poll_timer_)
+  {
     poll_timer_->cancel();
   }
   emcy_queue_.reset();

--- a/canopen_base_driver/package.xml
+++ b/canopen_base_driver/package.xml
@@ -17,7 +17,6 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>boost</depend>
   <depend>diagnostic_updater</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/canopen_core/ConfigExtras.cmake
+++ b/canopen_core/ConfigExtras.cmake
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-find_package(Boost REQUIRED system thread)
+find_package(Boost REQUIRED thread)

--- a/canopen_core/package.xml
+++ b/canopen_core/package.xml
@@ -9,14 +9,18 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>boost</build_depend>
+
+  <build_export_depend>boost</build_export_depend>
+
   <depend>canopen_interfaces</depend>
   <depend>lely_core_libraries</depend>
+  <depend>libboost-thread</depend>
   <depend>lifecycle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>yaml_cpp_vendor</depend>
-  <depend>boost</depend>
 
   <test_depend>ament_lint_auto</test_depend>
 


### PR DESCRIPTION
I'm trying to remove the libboost-all-dev from my robot image. I notices there is an exec_depend from `ros2_canopen` to libboost-all-dev. This is not needed for running the application, only for compiling. So I've tried to look at all the boost dependencies and categorized them properly.

canopen_402_driver:
 - uses the headers of boost container and numeric which are part of libboost-all-dev

canopen_base_driver:
 - doesn't depend on boost

canopen_core:
 - boost thread requires linking to libboost-thread and the headers from libboost-all-dev
 - it uses the headers of boost lockfree and optional which are part of libboost-dev