### PR TITLE
Implement CiA 402-2 multi-channel support for multiple axes per CANopen node

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | Buildfarm Build (kilted) | [![Buildfarm Status](https://build.ros2.org/job/Kdev__ros2_canopen__ubuntu_noble_amd64/badge/icon)](https://build.ros2.org/job/Kdev__ros2_canopen__ubuntu_noble_amd64/) |
 | Buildfarm Build (jazzy) | [![Buildfarm Status](https://build.ros2.org/job/Jdev__ros2_canopen__ubuntu_noble_amd64/badge/icon)](https://build.ros2.org/job/Jdev__ros2_canopen__ubuntu_noble_amd64/) |
 
-The stack is currently under development and not yet ready for production use. 
+The stack is currently under development and not yet ready for production use.
 
 ## Documentation
 The documentation consists of two parts: a manual and an api reference.

--- a/canopen_402_driver/include/canopen_402_driver/cia402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/cia402_driver.hpp
@@ -74,13 +74,22 @@ public:
 
   double get_speed(uint8_t channel = 0) { return node_canopen_402_driver_->get_speed(channel); }
 
-  double get_position(uint8_t channel = 0) { return node_canopen_402_driver_->get_position(channel); }
+  double get_position(uint8_t channel = 0)
+  {
+    return node_canopen_402_driver_->get_position(channel);
+  }
 
-  bool set_target(double target, uint8_t channel = 0) { return node_canopen_402_driver_->set_target(target, channel); }
+  bool set_target(double target, uint8_t channel = 0)
+  {
+    return node_canopen_402_driver_->set_target(target, channel);
+  }
 
   bool init_motor(uint8_t channel = 0) { return node_canopen_402_driver_->init_motor(channel); }
 
-  bool recover_motor(uint8_t channel = 0) { return node_canopen_402_driver_->recover_motor(channel); }
+  bool recover_motor(uint8_t channel = 0)
+  {
+    return node_canopen_402_driver_->recover_motor(channel);
+  }
 
   bool halt_motor(uint8_t channel = 0) { return node_canopen_402_driver_->halt_motor(channel); }
 

--- a/canopen_402_driver/include/canopen_402_driver/cia402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/cia402_driver.hpp
@@ -16,6 +16,7 @@
 
 #ifndef CANOPEN_402_DRIVER__402_DRIVER_HPP_
 #define CANOPEN_402_DRIVER__402_DRIVER_HPP_
+#include <cstdint>
 #include "canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp"
 #include "canopen_core/driver_node.hpp"
 
@@ -69,25 +70,25 @@ public:
     node_canopen_402_driver_->register_rpdo_cb(rpdo_cb);
   }
 
-  double get_effort() { return node_canopen_402_driver_->get_effort(); }
+  double get_effort(uint8_t channel = 0) { return node_canopen_402_driver_->get_effort(channel); }
 
-  double get_speed() { return node_canopen_402_driver_->get_speed(); }
+  double get_speed(uint8_t channel = 0) { return node_canopen_402_driver_->get_speed(channel); }
 
-  double get_position() { return node_canopen_402_driver_->get_position(); }
+  double get_position(uint8_t channel = 0) { return node_canopen_402_driver_->get_position(channel); }
 
-  bool set_target(double target) { return node_canopen_402_driver_->set_target(target); }
+  bool set_target(double target, uint8_t channel = 0) { return node_canopen_402_driver_->set_target(target, channel); }
 
-  bool init_motor() { return node_canopen_402_driver_->init_motor(); }
+  bool init_motor(uint8_t channel = 0) { return node_canopen_402_driver_->init_motor(channel); }
 
-  bool recover_motor() { return node_canopen_402_driver_->recover_motor(); }
+  bool recover_motor(uint8_t channel = 0) { return node_canopen_402_driver_->recover_motor(channel); }
 
-  bool halt_motor() { return node_canopen_402_driver_->halt_motor(); }
+  bool halt_motor(uint8_t channel = 0) { return node_canopen_402_driver_->halt_motor(channel); }
 
-  uint16_t get_mode() { return node_canopen_402_driver_->get_mode(); }
+  uint16_t get_mode(uint8_t channel = 0) { return node_canopen_402_driver_->get_mode(channel); }
 
-  bool set_operation_mode(uint16_t mode)
+  bool set_operation_mode(uint16_t mode, uint8_t channel = 0)
   {
-    return node_canopen_402_driver_->set_operation_mode(mode);
+    return node_canopen_402_driver_->set_operation_mode(mode, channel);
   }
 };
 }  // namespace ros2_canopen

--- a/canopen_402_driver/include/canopen_402_driver/default_homing_mode.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/default_homing_mode.hpp
@@ -52,7 +52,9 @@ class DefaultHomingMode : public HomingMode
   }
 
 public:
-  DefaultHomingMode(std::shared_ptr<LelyDriverBridge> driver, int homing_timeout_seconds, uint16_t channel_offset = 0)
+  DefaultHomingMode(
+    std::shared_ptr<LelyDriverBridge> driver, int homing_timeout_seconds,
+    uint16_t channel_offset = 0)
   : homing_timeout_seconds_(homing_timeout_seconds), channel_offset_(channel_offset)
   {
     this->driver = driver;

--- a/canopen_402_driver/include/canopen_402_driver/default_homing_mode.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/default_homing_mode.hpp
@@ -26,7 +26,8 @@ namespace ros2_canopen
 
 class DefaultHomingMode : public HomingMode
 {
-  const uint16_t index = 0x6098;
+  const uint16_t base_index = 0x6098;
+  uint16_t channel_offset_;  // Channel offset for multi-axis support (CiA 402-2)
   std::shared_ptr<LelyDriverBridge> driver;
 
   std::atomic<bool> execute_;
@@ -51,8 +52,8 @@ class DefaultHomingMode : public HomingMode
   }
 
 public:
-  DefaultHomingMode(std::shared_ptr<LelyDriverBridge> driver, int homing_timeout_seconds)
-  : homing_timeout_seconds_(homing_timeout_seconds)
+  DefaultHomingMode(std::shared_ptr<LelyDriverBridge> driver, int homing_timeout_seconds, uint16_t channel_offset = 0)
+  : homing_timeout_seconds_(homing_timeout_seconds), channel_offset_(channel_offset)
   {
     this->driver = driver;
   }

--- a/canopen_402_driver/include/canopen_402_driver/mode_forward_helper.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/mode_forward_helper.hpp
@@ -33,8 +33,8 @@ class ModeForwardHelper : public ModeTargetHelper<TYPE>
   uint16_t channel_offset_;  // Channel offset for multi-axis support (CiA 402-2)
 
 public:
-  ModeForwardHelper(std::shared_ptr<LelyDriverBridge> driver, uint16_t channel_offset = 0) 
-    : ModeTargetHelper<TYPE>(ID), channel_offset_(channel_offset)
+  ModeForwardHelper(std::shared_ptr<LelyDriverBridge> driver, uint16_t channel_offset = 0)
+  : ModeTargetHelper<TYPE>(ID), channel_offset_(channel_offset)
   {
     this->driver = driver;
   }

--- a/canopen_402_driver/include/canopen_402_driver/mode_forward_helper.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/mode_forward_helper.hpp
@@ -30,9 +30,11 @@ template <uint16_t ID, typename TYPE, uint16_t OBJ, uint8_t SUB, uint16_t CW_MAS
 class ModeForwardHelper : public ModeTargetHelper<TYPE>
 {
   std::shared_ptr<LelyDriverBridge> driver;
+  uint16_t channel_offset_;  // Channel offset for multi-axis support (CiA 402-2)
 
 public:
-  ModeForwardHelper(std::shared_ptr<LelyDriverBridge> driver) : ModeTargetHelper<TYPE>(ID)
+  ModeForwardHelper(std::shared_ptr<LelyDriverBridge> driver, uint16_t channel_offset = 0) 
+    : ModeTargetHelper<TYPE>(ID), channel_offset_(channel_offset)
   {
     this->driver = driver;
   }
@@ -43,7 +45,8 @@ public:
     {
       cw = cw.get() | CW_MASK;
 
-      driver->universal_set_value<TYPE>(OBJ, SUB, this->getTarget());
+      // Apply channel offset to object dictionary index
+      driver->universal_set_value<TYPE>(OBJ + channel_offset_, SUB, this->getTarget());
       return true;
     }
     else

--- a/canopen_402_driver/include/canopen_402_driver/motor.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/motor.hpp
@@ -86,10 +86,7 @@ public:
    * @param base_index The base object dictionary index
    * @return The channel-specific index
    */
-  uint16_t get_channel_index(uint16_t base_index) const
-  {
-    return base_index + channel_offset_;
-  }
+  uint16_t get_channel_index(uint16_t base_index) const { return base_index + channel_offset_; }
 
   uint8_t get_channel() const { return channel_; }
 
@@ -212,11 +209,16 @@ public:
     registerMode<VelocityMode>(MotorBase::Velocity, driver, channel_offset_);
     registerMode<ProfiledVelocityMode>(MotorBase::Profiled_Velocity, driver, channel_offset_);
     registerMode<ProfiledTorqueMode>(MotorBase::Profiled_Torque, driver, channel_offset_);
-    registerMode<DefaultHomingMode>(MotorBase::Homing, driver, homing_timeout_seconds_, channel_offset_);
-    registerMode<InterpolatedPositionMode>(MotorBase::Interpolated_Position, driver, channel_offset_);
-    registerMode<CyclicSynchronousPositionMode>(MotorBase::Cyclic_Synchronous_Position, driver, channel_offset_);
-    registerMode<CyclicSynchronousVelocityMode>(MotorBase::Cyclic_Synchronous_Velocity, driver, channel_offset_);
-    registerMode<CyclicSynchronousTorqueMode>(MotorBase::Cyclic_Synchronous_Torque, driver, channel_offset_);
+    registerMode<DefaultHomingMode>(
+      MotorBase::Homing, driver, homing_timeout_seconds_, channel_offset_);
+    registerMode<InterpolatedPositionMode>(
+      MotorBase::Interpolated_Position, driver, channel_offset_);
+    registerMode<CyclicSynchronousPositionMode>(
+      MotorBase::Cyclic_Synchronous_Position, driver, channel_offset_);
+    registerMode<CyclicSynchronousVelocityMode>(
+      MotorBase::Cyclic_Synchronous_Velocity, driver, channel_offset_);
+    registerMode<CyclicSynchronousTorqueMode>(
+      MotorBase::Cyclic_Synchronous_Torque, driver, channel_offset_);
   }
 
   double get_effort() const

--- a/canopen_402_driver/include/canopen_402_driver/motor.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/motor.hpp
@@ -61,15 +61,37 @@ class Motor402 : public MotorBase
 public:
   Motor402(
     std::shared_ptr<LelyDriverBridge> driver, ros2_canopen::State402::InternalState switching_state,
-    int homing_timeout_seconds)
+    int homing_timeout_seconds, uint8_t channel = 0)
   : MotorBase(),
     switching_state_(switching_state),
     monitor_mode_(true),
     state_switch_timeout_(5),
-    homing_timeout_seconds_(homing_timeout_seconds)
+    homing_timeout_seconds_(homing_timeout_seconds),
+    channel_(channel)
   {
     this->driver = driver;
+    // Calculate channel offset according to CiA 402-2: base_index + (channel * 0x800)
+    channel_offset_ = channel * 0x800;
   }
+
+  /**
+   * @brief Get channel-specific object dictionary index
+   *
+   * According to CiA 402-2, multi-axis devices use offset indices:
+   * - Channel 0: 0x6000-0x67FF (standard, no offset)
+   * - Channel 1: 0x6800-0x6FFF (offset +0x800)
+   * - Channel 2: 0x7000-0x77FF (offset +0x1000)
+   * - etc.
+   *
+   * @param base_index The base object dictionary index
+   * @return The channel-specific index
+   */
+  uint16_t get_channel_index(uint16_t base_index) const
+  {
+    return base_index + channel_offset_;
+  }
+
+  uint8_t get_channel() const { return channel_; }
 
   virtual bool setTarget(double val);
   virtual bool enterModeAndWait(uint16_t mode);
@@ -185,25 +207,30 @@ public:
    */
   virtual void registerDefaultModes()
   {
-    registerMode<ProfiledPositionMode>(MotorBase::Profiled_Position, driver);
-    registerMode<VelocityMode>(MotorBase::Velocity, driver);
-    registerMode<ProfiledVelocityMode>(MotorBase::Profiled_Velocity, driver);
-    registerMode<ProfiledTorqueMode>(MotorBase::Profiled_Torque, driver);
-    registerMode<DefaultHomingMode>(MotorBase::Homing, driver, homing_timeout_seconds_);
-    registerMode<InterpolatedPositionMode>(MotorBase::Interpolated_Position, driver);
-    registerMode<CyclicSynchronousPositionMode>(MotorBase::Cyclic_Synchronous_Position, driver);
-    registerMode<CyclicSynchronousVelocityMode>(MotorBase::Cyclic_Synchronous_Velocity, driver);
-    registerMode<CyclicSynchronousTorqueMode>(MotorBase::Cyclic_Synchronous_Torque, driver);
+    // Pass channel_offset_ to all mode constructors for multi-axis support
+    registerMode<ProfiledPositionMode>(MotorBase::Profiled_Position, driver, channel_offset_);
+    registerMode<VelocityMode>(MotorBase::Velocity, driver, channel_offset_);
+    registerMode<ProfiledVelocityMode>(MotorBase::Profiled_Velocity, driver, channel_offset_);
+    registerMode<ProfiledTorqueMode>(MotorBase::Profiled_Torque, driver, channel_offset_);
+    registerMode<DefaultHomingMode>(MotorBase::Homing, driver, homing_timeout_seconds_, channel_offset_);
+    registerMode<InterpolatedPositionMode>(MotorBase::Interpolated_Position, driver, channel_offset_);
+    registerMode<CyclicSynchronousPositionMode>(MotorBase::Cyclic_Synchronous_Position, driver, channel_offset_);
+    registerMode<CyclicSynchronousVelocityMode>(MotorBase::Cyclic_Synchronous_Velocity, driver, channel_offset_);
+    registerMode<CyclicSynchronousTorqueMode>(MotorBase::Cyclic_Synchronous_Torque, driver, channel_offset_);
   }
 
   double get_effort() const
   {
-    return (double)this->driver->universal_get_value<int16_t>(0x6077, 0);
+    return (double)this->driver->universal_get_value<int16_t>(get_channel_index(0x6077), 0);
   }
-  double get_speed() const { return (double)this->driver->universal_get_value<int32_t>(0x606C, 0); }
+  double get_speed() const
+  {
+    return (double)this->driver->universal_get_value<int32_t>(get_channel_index(0x606C), 0);
+  }
+
   double get_position() const
   {
-    return (double)this->driver->universal_get_value<int32_t>(0x6064, 0);
+    return (double)this->driver->universal_get_value<int32_t>(get_channel_index(0x6064), 0);
   }
 
   void set_diagnostic_status_msgs(std::shared_ptr<DiagnosticsCollector> status, bool enable)
@@ -244,6 +271,12 @@ private:
   const int homing_timeout_seconds_;
 
   std::shared_ptr<LelyDriverBridge> driver;
+
+  // Channel support for multi-axis devices (CiA 402-2)
+  const uint8_t channel_;
+  uint16_t channel_offset_;
+
+  // Base object dictionary indices (will be offset by channel_offset_)
   const uint16_t status_word_entry_index = 0x6041;
   const uint16_t control_word_entry_index = 0x6040;
   const uint16_t op_mode_display_index = 0x6061;

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -20,6 +20,11 @@
 #define NODE_CANOPEN_402_DRIVER
 
 #include <cstdint>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <vector>
+
 #include "canopen_402_driver/motor.hpp"
 #include "canopen_base_driver/lely_driver_bridge.hpp"
 #include "canopen_interfaces/srv/co_target_double.hpp"
@@ -40,33 +45,40 @@ class NodeCanopen402Driver : public NodeCanopenProxyDriver<NODETYPE>
     "NODETYPE must derive from rclcpp::Node or rclcpp_lifecycle::LifecycleNode");
 
 protected:
-  std::vector<std::shared_ptr<Motor402>> motors_;
+  struct ChannelContext
+  {
+    std::shared_ptr<Motor402> motor;
+
+    // Resolved (effective) per-channel scale/offset values
+    double scale_pos_to_dev{1000.0};
+    double scale_pos_from_dev{0.001};
+    double scale_vel_to_dev{1000.0};
+    double scale_vel_from_dev{0.001};
+    double scale_eff_from_dev{0.001};
+    double offset_pos_to_dev{0.0};
+    double offset_pos_from_dev{0.0};
+
+    // Per-channel service handles (kept alive by owning SharedPtr)
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_init;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_enable;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_disable;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_halt;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_recover;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_position;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_torque;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_velocity;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_velocity;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_position;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_torque;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_interpolated_position;
+    rclcpp::Service<canopen_interfaces::srv::COTargetDouble>::SharedPtr handle_set_target;
+  };
+
+  std::vector<ChannelContext> channels_;
   uint8_t num_channels_;
   std::vector<std::string> channel_names_;
 
   rclcpp::TimerBase::SharedPtr timer_;
-
-  // Per-channel service handles (Option B: one service per channel)
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_init_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_enable_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_disable_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_halt_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_recover_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
-    handle_set_mode_position_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_torque_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
-    handle_set_mode_velocity_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
-    handle_set_mode_cyclic_velocity_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
-    handle_set_mode_cyclic_position_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
-    handle_set_mode_cyclic_torque_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
-    handle_set_mode_interpolated_position_services_;
-  std::vector<rclcpp::Service<canopen_interfaces::srv::COTargetDouble>::SharedPtr>
-    handle_set_target_services_;
 
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr publish_joint_state;
 
@@ -78,15 +90,6 @@ protected:
   double scale_eff_from_dev_;
   double offset_pos_to_dev_;
   double offset_pos_from_dev_;
-
-  // Per-channel scale/offset (optional overrides)
-  std::vector<double> channel_scale_pos_to_dev_;
-  std::vector<double> channel_scale_pos_from_dev_;
-  std::vector<double> channel_scale_vel_to_dev_;
-  std::vector<double> channel_scale_vel_from_dev_;
-  std::vector<double> channel_scale_eff_from_dev_;
-  std::vector<double> channel_offset_pos_to_dev_;
-  std::vector<double> channel_offset_pos_from_dev_;
 
   ros2_canopen::State402::InternalState switching_state_;
   int homing_timeout_seconds_;
@@ -109,38 +112,27 @@ public:
 
   virtual double get_effort(uint8_t channel = 0)
   {
-    if (channel >= motors_.size()) return 0.0;
-    double scale = (channel < channel_scale_eff_from_dev_.size())
-                     ? channel_scale_eff_from_dev_[channel]
-                     : scale_eff_from_dev_;
-    return motors_[channel]->get_effort() * scale;
+    if (channel >= channels_.size() || !channels_[channel].motor) return 0.0;
+    return channels_[channel].motor->get_effort() * channels_[channel].scale_eff_from_dev;
   }
 
   virtual double get_speed(uint8_t channel = 0)
   {
-    if (channel >= motors_.size()) return 0.0;
-    double scale = (channel < channel_scale_vel_from_dev_.size())
-                     ? channel_scale_vel_from_dev_[channel]
-                     : scale_vel_from_dev_;
-    return motors_[channel]->get_speed() * scale;
+    if (channel >= channels_.size() || !channels_[channel].motor) return 0.0;
+    return channels_[channel].motor->get_speed() * channels_[channel].scale_vel_from_dev;
   }
 
   virtual double get_position(uint8_t channel = 0)
   {
-    if (channel >= motors_.size()) return 0.0;
-    double scale = (channel < channel_scale_pos_from_dev_.size())
-                     ? channel_scale_pos_from_dev_[channel]
-                     : scale_pos_from_dev_;
-    double offset = (channel < channel_offset_pos_from_dev_.size())
-                      ? channel_offset_pos_from_dev_[channel]
-                      : offset_pos_from_dev_;
-    return motors_[channel]->get_position() * scale + offset;
+    if (channel >= channels_.size() || !channels_[channel].motor) return 0.0;
+    return channels_[channel].motor->get_position() * channels_[channel].scale_pos_from_dev +
+           channels_[channel].offset_pos_from_dev;
   }
 
   virtual uint16_t get_mode(uint8_t channel = 0)
   {
-    if (channel >= motors_.size()) return 0;
-    return motors_[channel]->getMode();
+    if (channel >= channels_.size() || !channels_[channel].motor) return 0;
+    return channels_[channel].motor->getMode();
   }
 
   /**

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -52,14 +52,21 @@ protected:
   std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_disable_services_;
   std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_halt_services_;
   std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_recover_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_position_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
+    handle_set_mode_position_services_;
   std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_torque_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_velocity_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_cyclic_velocity_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_cyclic_position_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_cyclic_torque_services_;
-  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_interpolated_position_services_;
-  std::vector<rclcpp::Service<canopen_interfaces::srv::COTargetDouble>::SharedPtr> handle_set_target_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
+    handle_set_mode_velocity_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
+    handle_set_mode_cyclic_velocity_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
+    handle_set_mode_cyclic_position_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
+    handle_set_mode_cyclic_torque_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr>
+    handle_set_mode_interpolated_position_services_;
+  std::vector<rclcpp::Service<canopen_interfaces::srv::COTargetDouble>::SharedPtr>
+    handle_set_target_services_;
 
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr publish_joint_state;
 
@@ -103,26 +110,30 @@ public:
   virtual double get_effort(uint8_t channel = 0)
   {
     if (channel >= motors_.size()) return 0.0;
-    double scale = (channel < channel_scale_eff_from_dev_.size()) ?
-                   channel_scale_eff_from_dev_[channel] : scale_eff_from_dev_;
+    double scale = (channel < channel_scale_eff_from_dev_.size())
+                     ? channel_scale_eff_from_dev_[channel]
+                     : scale_eff_from_dev_;
     return motors_[channel]->get_effort() * scale;
   }
 
   virtual double get_speed(uint8_t channel = 0)
   {
     if (channel >= motors_.size()) return 0.0;
-    double scale = (channel < channel_scale_vel_from_dev_.size()) ?
-                   channel_scale_vel_from_dev_[channel] : scale_vel_from_dev_;
+    double scale = (channel < channel_scale_vel_from_dev_.size())
+                     ? channel_scale_vel_from_dev_[channel]
+                     : scale_vel_from_dev_;
     return motors_[channel]->get_speed() * scale;
   }
 
   virtual double get_position(uint8_t channel = 0)
   {
     if (channel >= motors_.size()) return 0.0;
-    double scale = (channel < channel_scale_pos_from_dev_.size()) ?
-                   channel_scale_pos_from_dev_[channel] : scale_pos_from_dev_;
-    double offset = (channel < channel_offset_pos_from_dev_.size()) ?
-                    channel_offset_pos_from_dev_[channel] : offset_pos_from_dev_;
+    double scale = (channel < channel_scale_pos_from_dev_.size())
+                     ? channel_scale_pos_from_dev_[channel]
+                     : scale_pos_from_dev_;
+    double offset = (channel < channel_offset_pos_from_dev_.size())
+                      ? channel_offset_pos_from_dev_[channel]
+                      : offset_pos_from_dev_;
     return motors_[channel]->get_position() * scale + offset;
   }
 
@@ -358,7 +369,8 @@ public:
    */
   void handle_set_target(
     const canopen_interfaces::srv::COTargetDouble::Request::SharedPtr request,
-    canopen_interfaces::srv::COTargetDouble::Response::SharedPtr response, const uint8_t channel = 0);
+    canopen_interfaces::srv::COTargetDouble::Response::SharedPtr response,
+    const uint8_t channel = 0);
 
   /**
    * @brief Method to set target

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -19,6 +19,7 @@
 #ifndef NODE_CANOPEN_402_DRIVER
 #define NODE_CANOPEN_402_DRIVER
 
+#include <cstdint>
 #include "canopen_402_driver/motor.hpp"
 #include "canopen_base_driver/lely_driver_bridge.hpp"
 #include "canopen_interfaces/srv/co_target_double.hpp"
@@ -39,22 +40,30 @@ class NodeCanopen402Driver : public NodeCanopenProxyDriver<NODETYPE>
     "NODETYPE must derive from rclcpp::Node or rclcpp_lifecycle::LifecycleNode");
 
 protected:
-  std::shared_ptr<Motor402> motor_;
+  std::vector<std::shared_ptr<Motor402>> motors_;
+  uint8_t num_channels_;
+  std::vector<std::string> channel_names_;
+
   rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_init_service;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_enable_service;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_disable_service;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_halt_service;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_recover_service;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_position_service;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_torque_service;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_velocity_service;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_velocity_service;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_position_service;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_cyclic_torque_service;
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr handle_set_mode_interpolated_position_service;
-  rclcpp::Service<canopen_interfaces::srv::COTargetDouble>::SharedPtr handle_set_target_service;
+
+  // Per-channel service handles (Option B: one service per channel)
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_init_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_enable_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_disable_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_halt_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_recover_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_position_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_torque_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_velocity_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_cyclic_velocity_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_cyclic_position_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_cyclic_torque_services_;
+  std::vector<rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr> handle_set_mode_interpolated_position_services_;
+  std::vector<rclcpp::Service<canopen_interfaces::srv::COTargetDouble>::SharedPtr> handle_set_target_services_;
+
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr publish_joint_state;
+
+  // Global scale/offset (used as defaults)
   double scale_pos_to_dev_;
   double scale_pos_from_dev_;
   double scale_vel_to_dev_;
@@ -62,12 +71,25 @@ protected:
   double scale_eff_from_dev_;
   double offset_pos_to_dev_;
   double offset_pos_from_dev_;
+
+  // Per-channel scale/offset (optional overrides)
+  std::vector<double> channel_scale_pos_to_dev_;
+  std::vector<double> channel_scale_pos_from_dev_;
+  std::vector<double> channel_scale_vel_to_dev_;
+  std::vector<double> channel_scale_vel_from_dev_;
+  std::vector<double> channel_scale_eff_from_dev_;
+  std::vector<double> channel_offset_pos_to_dev_;
+  std::vector<double> channel_offset_pos_from_dev_;
+
   ros2_canopen::State402::InternalState switching_state_;
   int homing_timeout_seconds_;
 
   void publish();
   virtual void poll_timer_callback() override;
   void diagnostic_callback(diagnostic_updater::DiagnosticStatusWrapper & stat) override;
+
+  // Helper to create per-channel services after configure
+  void create_per_channel_services();
 
 public:
   NodeCanopen402Driver(NODETYPE * node);
@@ -78,16 +100,37 @@ public:
   virtual void deactivate(bool called_from_base) override;
   virtual void add_to_master() override;
 
-  virtual double get_effort() { return motor_->get_effort() * scale_eff_from_dev_; }
-
-  virtual double get_speed() { return motor_->get_speed() * scale_vel_from_dev_; }
-
-  virtual double get_position()
+  virtual double get_effort(uint8_t channel = 0)
   {
-    return motor_->get_position() * scale_pos_from_dev_ + offset_pos_from_dev_;
+    if (channel >= motors_.size()) return 0.0;
+    double scale = (channel < channel_scale_eff_from_dev_.size()) ?
+                   channel_scale_eff_from_dev_[channel] : scale_eff_from_dev_;
+    return motors_[channel]->get_effort() * scale;
   }
 
-  virtual uint16_t get_mode() { return motor_->getMode(); }
+  virtual double get_speed(uint8_t channel = 0)
+  {
+    if (channel >= motors_.size()) return 0.0;
+    double scale = (channel < channel_scale_vel_from_dev_.size()) ?
+                   channel_scale_vel_from_dev_[channel] : scale_vel_from_dev_;
+    return motors_[channel]->get_speed() * scale;
+  }
+
+  virtual double get_position(uint8_t channel = 0)
+  {
+    if (channel >= motors_.size()) return 0.0;
+    double scale = (channel < channel_scale_pos_from_dev_.size()) ?
+                   channel_scale_pos_from_dev_[channel] : scale_pos_from_dev_;
+    double offset = (channel < channel_offset_pos_from_dev_.size()) ?
+                    channel_offset_pos_from_dev_[channel] : offset_pos_from_dev_;
+    return motors_[channel]->get_position() * scale + offset;
+  }
+
+  virtual uint16_t get_mode(uint8_t channel = 0)
+  {
+    if (channel >= motors_.size()) return 0;
+    return motors_[channel]->getMode();
+  }
 
   /**
    * @brief Service Callback to initialise device
@@ -100,7 +143,7 @@ public:
    */
   void handle_init(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Service Callback to enable device
@@ -113,7 +156,7 @@ public:
    */
   void handle_enable(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Service Callback to disable device
@@ -126,7 +169,7 @@ public:
    */
   void handle_disable(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Method to initialise device
@@ -139,7 +182,7 @@ public:
    * @return  bool
    * Indicates initialisation procedure result
    */
-  bool init_motor();
+  bool init_motor(uint8_t channel = 0);
 
   /**
    * @brief Service Callback to recover device
@@ -152,7 +195,7 @@ public:
    */
   void handle_recover(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Method to recover device
@@ -164,7 +207,7 @@ public:
    *
    * @return bool
    */
-  bool recover_motor();
+  bool recover_motor(uint8_t channel = 0);
 
   /**
    * @brief Service Callback to halt device
@@ -178,7 +221,7 @@ public:
    */
   void handle_halt(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Method to halt device
@@ -191,7 +234,7 @@ public:
    *
    * @return bool
    */
-  bool halt_motor();
+  bool halt_motor(uint8_t channel = 0);
 
   /**
    * @brief Service Callback to set operation mode
@@ -203,7 +246,7 @@ public:
    * MotorBase::Cyclic_Velocity or MotorBase::Cyclic_Torque or MotorBase::Interpolated_Position
    * @param [out] response
    */
-  bool set_operation_mode(uint16_t mode);
+  bool set_operation_mode(uint16_t mode, uint8_t channel = 0);
 
   /**
    * @brief Service Callback to set profiled position mode
@@ -217,7 +260,7 @@ public:
    */
   void handle_set_mode_position(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Service Callback to set profiled velocity mode
@@ -231,7 +274,7 @@ public:
    */
   void handle_set_mode_velocity(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Service Callback to set cyclic position mode
@@ -245,7 +288,7 @@ public:
    */
   void handle_set_mode_cyclic_position(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Service Callback to set interpolated position mode
@@ -259,7 +302,7 @@ public:
    */
   void handle_set_mode_interpolated_position(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Service Callback to set cyclic velocity mode
@@ -273,7 +316,7 @@ public:
    */
   void handle_set_mode_cyclic_velocity(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Service Callback to set profiled torque mode
@@ -287,7 +330,7 @@ public:
    */
   void handle_set_mode_torque(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Service Callback to set cyclic torque mode
@@ -301,7 +344,7 @@ public:
    */
   void handle_set_mode_cyclic_torque(
     const std_srvs::srv::Trigger::Request::SharedPtr request,
-    std_srvs::srv::Trigger::Response::SharedPtr response);
+    std_srvs::srv::Trigger::Response::SharedPtr response, uint8_t channel = 0);
 
   /**
    * @brief Service Callback to set target
@@ -315,7 +358,7 @@ public:
    */
   void handle_set_target(
     const canopen_interfaces::srv::COTargetDouble::Request::SharedPtr request,
-    canopen_interfaces::srv::COTargetDouble::Response::SharedPtr response);
+    canopen_interfaces::srv::COTargetDouble::Response::SharedPtr response, const uint8_t channel = 0);
 
   /**
    * @brief Method to set target
@@ -325,10 +368,11 @@ public:
    * drives state.
    *
    * @param [in] double target value
+   * @param [in] uint8_t channel (default 0 for backward compatibility)
    *
    * @return bool
    */
-  bool set_target(double target);
+  bool set_target(double target, uint8_t channel = 0);
 };
 }  // namespace node_interfaces
 }  // namespace ros2_canopen

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -98,6 +98,9 @@ protected:
   virtual void poll_timer_callback() override;
   void diagnostic_callback(diagnostic_updater::DiagnosticStatusWrapper & stat) override;
 
+  // Shared configure logic for both rclcpp::Node and rclcpp_lifecycle::LifecycleNode
+  void configure_common();
+
   // Helper to create per-channel services after configure
   void create_per_channel_services();
 

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -19,6 +19,7 @@
 #ifndef NODE_CANOPEN_402_DRIVER_IMPL_HPP_
 #define NODE_CANOPEN_402_DRIVER_IMPL_HPP_
 
+#include <sys/types.h>
 #include "canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp"
 #include "canopen_core/driver_error.hpp"
 
@@ -45,84 +46,7 @@ void NodeCanopen402Driver<rclcpp::Node>::init(bool called_from_base)
   NodeCanopenProxyDriver<rclcpp::Node>::init(false);
   publish_joint_state =
     this->node_->create_publisher<sensor_msgs::msg::JointState>("~/joint_states", 1);
-  handle_init_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/init").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_init, this, std::placeholders::_1,
-      std::placeholders::_2));
-
-  handle_enable_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/enable").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_enable, this, std::placeholders::_1,
-      std::placeholders::_2));
-
-  handle_disable_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/disable").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_disable, this, std::placeholders::_1,
-      std::placeholders::_2));
-
-  handle_halt_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/halt").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_halt, this, std::placeholders::_1,
-      std::placeholders::_2));
-
-  handle_recover_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/recover").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_recover, this, std::placeholders::_1,
-      std::placeholders::_2));
-
-  handle_set_mode_position_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/position_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_set_mode_position, this, std::placeholders::_1,
-      std::placeholders::_2));
-
-  handle_set_mode_velocity_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/velocity_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_set_mode_velocity, this, std::placeholders::_1,
-      std::placeholders::_2));
-
-  handle_set_mode_cyclic_velocity_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/cyclic_velocity_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_set_mode_cyclic_velocity, this,
-      std::placeholders::_1, std::placeholders::_2));
-
-  handle_set_mode_cyclic_position_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/cyclic_position_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_set_mode_cyclic_position, this,
-      std::placeholders::_1, std::placeholders::_2));
-
-  handle_set_mode_interpolated_position_service =
-    this->node_->create_service<std_srvs::srv::Trigger>(
-      std::string(this->node_->get_name()).append("/interpolated_position_mode").c_str(),
-      std::bind(
-        &NodeCanopen402Driver<rclcpp::Node>::handle_set_mode_interpolated_position, this,
-        std::placeholders::_1, std::placeholders::_2));
-
-  handle_set_mode_torque_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/torque_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_set_mode_torque, this, std::placeholders::_1,
-      std::placeholders::_2));
-
-  handle_set_mode_cyclic_torque_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/cyclic_torque_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_set_mode_cyclic_torque, this,
-      std::placeholders::_1, std::placeholders::_2));
-
-  handle_set_target_service = this->node_->create_service<canopen_interfaces::srv::COTargetDouble>(
-    std::string(this->node_->get_name()).append("/target").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp::Node>::handle_set_target, this, std::placeholders::_1,
-      std::placeholders::_2));
+  // Per-channel services will be created in configure() after num_channels_ is known
 }
 
 template <>
@@ -131,84 +55,158 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::init(bool called_fro
   NodeCanopenProxyDriver<rclcpp_lifecycle::LifecycleNode>::init(false);
   publish_joint_state =
     this->node_->create_publisher<sensor_msgs::msg::JointState>("~/joint_states", 10);
-  handle_init_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/init").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_init, this,
-      std::placeholders::_1, std::placeholders::_2));
+  // Per-channel services will be created in configure() after num_channels_ is known
+}
 
-  handle_enable_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/enable").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_enable, this,
-      std::placeholders::_1, std::placeholders::_2));
+// Helper method to create per-channel services (called from configure)
+template <class NODETYPE>
+void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
+{
+  // Resize service vectors
+  handle_init_services_.resize(num_channels_);
+  handle_enable_services_.resize(num_channels_);
+  handle_disable_services_.resize(num_channels_);
+  handle_halt_services_.resize(num_channels_);
+  handle_recover_services_.resize(num_channels_);
+  handle_set_mode_position_services_.resize(num_channels_);
+  handle_set_mode_torque_services_.resize(num_channels_);
+  handle_set_mode_velocity_services_.resize(num_channels_);
+  handle_set_mode_cyclic_velocity_services_.resize(num_channels_);
+  handle_set_mode_cyclic_position_services_.resize(num_channels_);
+  handle_set_mode_cyclic_torque_services_.resize(num_channels_);
+  handle_set_mode_interpolated_position_services_.resize(num_channels_);
+  handle_set_target_services_.resize(num_channels_);
 
-  handle_disable_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/disable").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_disable, this,
-      std::placeholders::_1, std::placeholders::_2));
+  // Create services for each channel
+  for (uint8_t ch = 0; ch < num_channels_; ++ch)
+  {
+    // Service naming:
+    // - Single-channel (num_channels_ == 1): Use legacy names like "init", "target", etc.
+    // - Multi-channel: Use channel_name as prefix like "channel_name/init"
+    std::string service_prefix;
+    if (num_channels_ == 1)
+    {
+      // Single-channel: no prefix, legacy behavior
+      service_prefix = "";
+    }
+    else
+    {
+      // Multi-channel: use channel_name as prefix
+      if (ch < channel_names_.size())
+      {
+        service_prefix = channel_names_[ch] + "/";
+      }
+      else
+      {
+        // Fallback if channel_names not configured
+        service_prefix = "ch" + std::to_string(ch) + "/";
+      }
+    }
 
-  handle_halt_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/halt").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_halt, this,
-      std::placeholders::_1, std::placeholders::_2));
+    // Init service
+    handle_init_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "init",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_init(request, response, ch);
+      });
 
-  handle_recover_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/recover").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_recover, this,
-      std::placeholders::_1, std::placeholders::_2));
+    // Enable service
+    handle_enable_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "enable",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_enable(request, response, ch);
+      });
 
-  handle_set_mode_position_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/position_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_set_mode_position, this,
-      std::placeholders::_1, std::placeholders::_2));
+    // Disable service
+    handle_disable_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "disable",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_disable(request, response, ch);
+      });
 
-  handle_set_mode_velocity_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/velocity_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_set_mode_velocity, this,
-      std::placeholders::_1, std::placeholders::_2));
+    // Halt service
+    handle_halt_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "halt",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_halt(request, response, ch);
+      });
 
-  handle_set_mode_cyclic_velocity_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/cyclic_velocity_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_set_mode_cyclic_velocity, this,
-      std::placeholders::_1, std::placeholders::_2));
+    // Recover service
+    handle_recover_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "recover",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_recover(request, response, ch);
+      });
 
-  handle_set_mode_cyclic_position_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/cyclic_position_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_set_mode_cyclic_position, this,
-      std::placeholders::_1, std::placeholders::_2));
+    // Position mode service
+    handle_set_mode_position_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "position_mode",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_set_mode_position(request, response, ch);
+      });
 
-  handle_set_mode_interpolated_position_service = this->node_->create_service<
-    std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/interpolated_position_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_set_mode_interpolated_position,
-      this, std::placeholders::_1, std::placeholders::_2));
+    // Velocity mode service
+    handle_set_mode_velocity_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "velocity_mode",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_set_mode_velocity(request, response, ch);
+      });
 
-  handle_set_mode_torque_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/torque_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_set_mode_torque, this,
-      std::placeholders::_1, std::placeholders::_2));
+    // Torque mode service
+    handle_set_mode_torque_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "torque_mode",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_set_mode_torque(request, response, ch);
+      });
 
-  handle_set_mode_cyclic_torque_service = this->node_->create_service<std_srvs::srv::Trigger>(
-    std::string(this->node_->get_name()).append("/cyclic_torque_mode").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_set_mode_cyclic_torque, this,
-      std::placeholders::_1, std::placeholders::_2));
+    // Cyclic velocity mode service
+    handle_set_mode_cyclic_velocity_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "cyclic_velocity_mode",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_set_mode_cyclic_velocity(request, response, ch);
+      });
 
-  handle_set_target_service = this->node_->create_service<canopen_interfaces::srv::COTargetDouble>(
-    std::string(this->node_->get_name()).append("/target").c_str(),
-    std::bind(
-      &NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::handle_set_target, this,
-      std::placeholders::_1, std::placeholders::_2));
+    // Cyclic position mode service
+    handle_set_mode_cyclic_position_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "cyclic_position_mode",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_set_mode_cyclic_position(request, response, ch);
+      });
+
+    // Cyclic torque mode service
+    handle_set_mode_cyclic_torque_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "cyclic_torque_mode",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_set_mode_cyclic_torque(request, response, ch);
+      });
+
+    // Interpolated position mode service
+    handle_set_mode_interpolated_position_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+      service_prefix + "interpolated_position_mode",
+      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
+                 std_srvs::srv::Trigger::Response::SharedPtr response) {
+        this->handle_set_mode_interpolated_position(request, response, ch);
+      });
+
+    // Target service (uses COTargetDouble without channel field, since channel is in service name)
+    handle_set_target_services_[ch] = this->node_->template create_service<canopen_interfaces::srv::COTargetDouble>(
+      service_prefix + "target",
+      [this, ch](const canopen_interfaces::srv::COTargetDouble::Request::SharedPtr request,
+                 canopen_interfaces::srv::COTargetDouble::Response::SharedPtr response) {
+        response->success = this->set_target(request->target, ch);
+      });
+  }
 }
 
 template <>
@@ -282,7 +280,7 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
   }
   try
   {
-    homing_timeout_seconds = std::optional(this->config_["homing_timout_seconds"].as<int>());
+    homing_timeout_seconds = std::optional(this->config_["homing_timeout_seconds"].as<int>());
   }
   catch (...)
   {
@@ -300,13 +298,72 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
   switching_state_ = (ros2_canopen::State402::InternalState)switching_state.value_or(
     (int)ros2_canopen::State402::InternalState::Operation_Enable);
   homing_timeout_seconds_ = homing_timeout_seconds.value_or(10);
+
+  // Multi-channel configuration
+  num_channels_ = 1;
+  try { num_channels_ = this->config_["num_channels"].as<uint8_t>(); } catch (...) {}
+
+  // Parse channel names
+  try
+  {
+    auto names_node = this->config_["channel_names"];
+    if (names_node.IsDefined() && names_node.IsSequence())
+    {
+      for (size_t i = 0; i < names_node.size(); ++i)
+      {
+        channel_names_.push_back(names_node[i].as<std::string>());
+      }
+    }
+  }
+  catch (...) {}
+
+  // Generate default names if not provided
+  if (channel_names_.empty())
+  {
+    for (uint8_t i = 0; i < num_channels_; ++i)
+    {
+      channel_names_.push_back(std::string(this->node_->get_name()) + "/" + std::to_string(i));
+    }
+  }
+
+  // Parse per-channel scales/offsets
+  try
+  {
+    auto channels_node = this->config_["channels"];
+    if (channels_node.IsDefined() && channels_node.IsSequence())
+    {
+      for (size_t i = 0; i < channels_node.size() && i < num_channels_; ++i)
+      {
+        auto ch = channels_node[i];
+        try { channel_scale_pos_to_dev_.push_back(ch["scale_pos_to_dev"].as<double>()); }
+        catch (...) { channel_scale_pos_to_dev_.push_back(scale_pos_to_dev_); }
+        try { channel_scale_pos_from_dev_.push_back(ch["scale_pos_from_dev"].as<double>()); }
+        catch (...) { channel_scale_pos_from_dev_.push_back(scale_pos_from_dev_); }
+        try { channel_scale_vel_to_dev_.push_back(ch["scale_vel_to_dev"].as<double>()); }
+        catch (...) { channel_scale_vel_to_dev_.push_back(scale_vel_to_dev_); }
+        try { channel_scale_vel_from_dev_.push_back(ch["scale_vel_from_dev"].as<double>()); }
+        catch (...) { channel_scale_vel_from_dev_.push_back(scale_vel_from_dev_); }
+        try { channel_scale_eff_from_dev_.push_back(ch["scale_eff_from_dev"].as<double>()); }
+        catch (...) { channel_scale_eff_from_dev_.push_back(scale_eff_from_dev_); }
+        try { channel_offset_pos_to_dev_.push_back(ch["offset_pos_to_dev"].as<double>()); }
+        catch (...) { channel_offset_pos_to_dev_.push_back(offset_pos_to_dev_); }
+        try { channel_offset_pos_from_dev_.push_back(ch["offset_pos_from_dev"].as<double>()); }
+        catch (...) { channel_offset_pos_from_dev_.push_back(offset_pos_from_dev_); }
+      }
+    }
+  }
+  catch (...) {}
+
   RCLCPP_INFO(
     this->node_->get_logger(),
-    "scale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ "
-    "%f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ "
+    "num_channels: %u\nscale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ "
+    "%f\nscale_eff_from_dev_ %f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ "
     "%f\nhoming_timeout_seconds_ %i\n",
-    scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_,
-    offset_pos_to_dev_, offset_pos_from_dev_, homing_timeout_seconds_);
+    num_channels_, scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_,
+    scale_eff_from_dev_, offset_pos_to_dev_, offset_pos_from_dev_, homing_timeout_seconds_);
+
+  // Create per-channel services
+  create_per_channel_services();
 }
 
 template <>
@@ -398,21 +455,84 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
   switching_state_ = (ros2_canopen::State402::InternalState)switching_state.value_or(
     (int)ros2_canopen::State402::InternalState::Operation_Enable);
   homing_timeout_seconds_ = homing_timeout_seconds.value_or(10);
+
+  // Multi-channel configuration
+  num_channels_ = 1;
+  try { num_channels_ = this->config_["num_channels"].as<uint8_t>(); } catch (...) {}
+
+  // Parse channel names
+  try
+  {
+    auto names_node = this->config_["channel_names"];
+    if (names_node.IsDefined() && names_node.IsSequence())
+    {
+      for (size_t i = 0; i < names_node.size(); ++i)
+      {
+        channel_names_.push_back(names_node[i].as<std::string>());
+      }
+    }
+  }
+  catch (...) {}
+
+  // Generate default names if not provided
+  if (channel_names_.empty())
+  {
+    for (uint8_t i = 0; i < num_channels_; ++i)
+    {
+      channel_names_.push_back(std::string(this->node_->get_name()) + "/" + std::to_string(i));
+    }
+  }
+
+  // Parse per-channel scales/offsets
+  try
+  {
+    auto channels_node = this->config_["channels"];
+    if (channels_node.IsDefined() && channels_node.IsSequence())
+    {
+      for (size_t i = 0; i < channels_node.size() && i < num_channels_; ++i)
+      {
+        auto ch = channels_node[i];
+        try { channel_scale_pos_to_dev_.push_back(ch["scale_pos_to_dev"].as<double>()); }
+        catch (...) { channel_scale_pos_to_dev_.push_back(scale_pos_to_dev_); }
+        try { channel_scale_pos_from_dev_.push_back(ch["scale_pos_from_dev"].as<double>()); }
+        catch (...) { channel_scale_pos_from_dev_.push_back(scale_pos_from_dev_); }
+        try { channel_scale_vel_to_dev_.push_back(ch["scale_vel_to_dev"].as<double>()); }
+        catch (...) { channel_scale_vel_to_dev_.push_back(scale_vel_to_dev_); }
+        try { channel_scale_vel_from_dev_.push_back(ch["scale_vel_from_dev"].as<double>()); }
+        catch (...) { channel_scale_vel_from_dev_.push_back(scale_vel_from_dev_); }
+        try { channel_scale_eff_from_dev_.push_back(ch["scale_eff_from_dev"].as<double>()); }
+        catch (...) { channel_scale_eff_from_dev_.push_back(scale_eff_from_dev_); }
+        try { channel_offset_pos_to_dev_.push_back(ch["offset_pos_to_dev"].as<double>()); }
+        catch (...) { channel_offset_pos_to_dev_.push_back(offset_pos_to_dev_); }
+        try { channel_offset_pos_from_dev_.push_back(ch["offset_pos_from_dev"].as<double>()); }
+        catch (...) { channel_offset_pos_from_dev_.push_back(offset_pos_from_dev_); }
+      }
+    }
+  }
+  catch (...) {}
+
   RCLCPP_INFO(
     this->node_->get_logger(),
-    "scale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ "
+    "num_channels: %u\nscale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ "
     "%f\nscale_eff_from_dev_ %f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ "
     "%f\nhoming_timeout_seconds_ %i\n",
-    scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_,
+    num_channels_, scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_,
     scale_eff_from_dev_, offset_pos_to_dev_, offset_pos_from_dev_, homing_timeout_seconds_);
+
+  // Create per-channel services
+  create_per_channel_services();
 }
 
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::activate(bool called_from_base)
 {
   NodeCanopenProxyDriver<NODETYPE>::activate(false);
-  motor_->registerDefaultModes();
-  motor_->set_diagnostic_status_msgs(this->diagnostic_collector_, this->diagnostic_enabled_);
+  // Register default modes for all motor instances
+  for (auto& motor : motors_)
+  {
+    motor->registerDefaultModes();
+    motor->set_diagnostic_status_msgs(this->diagnostic_collector_, this->diagnostic_enabled_);
+  }
 }
 
 template <class NODETYPE>
@@ -426,8 +546,12 @@ template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::poll_timer_callback()
 {
   NodeCanopenProxyDriver<NODETYPE>::poll_timer_callback();
-  motor_->handleRead();
-  motor_->handleWrite();
+  // Handle read/write for all motors
+  for (auto& motor : motors_)
+  {
+    motor->handleRead();
+    motor->handleWrite();
+  }
   publish();
 }
 
@@ -435,10 +559,42 @@ template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::publish()
 {
   sensor_msgs::msg::JointState js_msg;
-  js_msg.name.push_back(this->node_->get_name());
-  js_msg.position.push_back(motor_->get_position() * scale_pos_from_dev_ + offset_pos_from_dev_);
-  js_msg.velocity.push_back(motor_->get_speed() * scale_vel_from_dev_);
-  js_msg.effort.push_back(motor_->get_effort() * scale_eff_from_dev_);
+  // Publish joint state for all channels
+  for (size_t ch = 0; ch < motors_.size(); ++ch)
+  {
+    std::string name;
+    if (num_channels_ == 1)
+    {
+      // Single-channel: use node name (legacy behavior)
+      name = std::string(this->node_->get_name());
+    }
+    else
+    {
+      // Multi-channel: use channel_name
+      if (ch < channel_names_.size())
+      {
+        name = channel_names_[ch];
+      }
+      else
+      {
+        // Fallback if channel_names not configured
+        name = std::string(this->node_->get_name()) + "/ch" + std::to_string(ch);
+      }
+    }
+
+    double scale_pos_from_dev = (ch < channel_scale_pos_from_dev_.size()) ?
+                       channel_scale_pos_from_dev_[ch] : scale_pos_from_dev_;
+    double offset_pos_from_dev = (ch < channel_offset_pos_from_dev_.size()) ?
+                        channel_offset_pos_from_dev_[ch] : offset_pos_from_dev_;
+    double scale_vel_from_dev = (ch < channel_scale_vel_from_dev_.size()) ?
+                       channel_scale_vel_from_dev_[ch] : scale_vel_from_dev_;
+    double scale_eff_from_dev = (ch < channel_scale_eff_from_dev_.size()) ?
+                       channel_scale_eff_from_dev_[ch] : scale_eff_from_dev_;
+    js_msg.name.push_back(name);
+    js_msg.position.push_back(motors_[ch]->get_position() * scale_pos_from_dev + offset_pos_from_dev);
+    js_msg.velocity.push_back(motors_[ch]->get_speed() * scale_vel_from_dev);
+    js_msg.effort.push_back(motors_[ch]->get_effort() * scale_eff_from_dev);
+  }
   publish_joint_state->publish(js_msg);
 }
 
@@ -446,157 +602,139 @@ template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::add_to_master()
 {
   NodeCanopenProxyDriver<NODETYPE>::add_to_master();
-  motor_ =
-    std::make_shared<Motor402>(this->lely_driver_, switching_state_, homing_timeout_seconds_);
+  // Create separate Motor402 instance for each channel
+  motors_.clear();
+  for (uint8_t ch = 0; ch < num_channels_; ++ch)
+  {
+    motors_.push_back(
+      std::make_shared<Motor402>(this->lely_driver_, switching_state_, homing_timeout_seconds_, ch)
+    );
+  }
 }
 
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_init(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
-  if (this->activated_.load())
-  {
-    bool temp = motor_->handleInit();
-    response->success = temp;
-  }
+  response->success = this->init_motor(channel);
 }
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_recover(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
-  if (this->activated_.load())
-  {
-    response->success = motor_->handleRecover();
-  }
+  response->success = this->recover_motor(channel);
 }
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_halt(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
-  if (this->activated_.load())
-  {
-    response->success = motor_->handleHalt();
-  }
+  response->success = this->halt_motor(channel);
 }
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_set_mode_position(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
-  response->success = set_operation_mode(MotorBase::Profiled_Position);
+  response->success = set_operation_mode(MotorBase::Profiled_Position, channel);
 }
 
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_set_mode_velocity(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
-  response->success = set_operation_mode(MotorBase::Profiled_Velocity);
+  response->success = set_operation_mode(MotorBase::Profiled_Velocity, channel);
 }
 
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_set_mode_cyclic_position(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
-  response->success = set_operation_mode(MotorBase::Cyclic_Synchronous_Position);
+  response->success = set_operation_mode(MotorBase::Cyclic_Synchronous_Position, channel);
 }
 
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_set_mode_interpolated_position(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
-  response->success = set_operation_mode(MotorBase::Interpolated_Position);
+  response->success = set_operation_mode(MotorBase::Interpolated_Position, channel);
 }
 
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_set_mode_cyclic_velocity(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
-  response->success = set_operation_mode(MotorBase::Cyclic_Synchronous_Velocity);
+  response->success = set_operation_mode(MotorBase::Cyclic_Synchronous_Velocity, channel);
 }
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_set_mode_torque(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
-  response->success = set_operation_mode(MotorBase::Profiled_Torque);
+  response->success = set_operation_mode(MotorBase::Profiled_Torque, channel);
 }
 
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_set_mode_cyclic_torque(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
-  response->success = set_operation_mode(MotorBase::Cyclic_Synchronous_Torque);
+  response->success = set_operation_mode(MotorBase::Cyclic_Synchronous_Torque, channel);
 }
 
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_set_target(
   const canopen_interfaces::srv::COTargetDouble::Request::SharedPtr request,
-  canopen_interfaces::srv::COTargetDouble::Response::SharedPtr response)
+  canopen_interfaces::srv::COTargetDouble::Response::SharedPtr response, const uint8_t channel)
 {
-  if (this->activated_.load())
-  {
-    auto mode = motor_->getMode();
-    double target;
-    if (
-      (mode == MotorBase::Profiled_Position) or (mode == MotorBase::Cyclic_Synchronous_Position) or
-      (mode == MotorBase::Interpolated_Position))
-    {
-      target = request->target * scale_pos_to_dev_ + offset_pos_to_dev_;
-    }
-    else if (
-      (mode == MotorBase::Velocity) or (mode == MotorBase::Profiled_Velocity) or
-      (mode == MotorBase::Cyclic_Synchronous_Velocity))
-    {
-      target = request->target * scale_vel_to_dev_;
-    }
-    else
-    {
-      target = request->target;
-    }
-
-    response->success = motor_->setTarget(target);
-  }
+    response->success = set_target(request->target, channel);
 }
 
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_disable(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
   if (this->activated_.load())
   {
-    bool temp = motor_->handleDisable();
-    response->success = temp;
+    response->success = motors_[channel]->handleDisable();
+  }
+  else {
+    response->success = false;
   }
 }
 
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::handle_enable(
   const std_srvs::srv::Trigger::Request::SharedPtr request,
-  std_srvs::srv::Trigger::Response::SharedPtr response)
+  std_srvs::srv::Trigger::Response::SharedPtr response, const uint8_t channel)
 {
   if (this->activated_.load())
   {
-    bool temp = motor_->handleEnable();
-    response->success = temp;
+    response->success = motors_[channel]->handleEnable();
+  }
+  else {
+    response->success = false;
   }
 }
 
 template <class NODETYPE>
-bool NodeCanopen402Driver<NODETYPE>::init_motor()
+bool NodeCanopen402Driver<NODETYPE>::init_motor(uint8_t channel)
 {
   if (this->activated_.load())
   {
-    bool temp = motor_->handleInit();
-    return temp;
+    if (channel >= motors_.size())
+    {
+      RCLCPP_ERROR(this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+      return false;
+    }
+    return motors_[channel]->handleInit();
   }
   else
   {
@@ -606,39 +744,55 @@ bool NodeCanopen402Driver<NODETYPE>::init_motor()
 }
 
 template <class NODETYPE>
-bool NodeCanopen402Driver<NODETYPE>::recover_motor()
+bool NodeCanopen402Driver<NODETYPE>::recover_motor(uint8_t channel)
 {
   if (this->activated_.load())
   {
-    return motor_->handleRecover();
-  }
-  else
-  {
-    return false;
-  }
-}
-
-template <class NODETYPE>
-bool NodeCanopen402Driver<NODETYPE>::halt_motor()
-{
-  if (this->activated_.load())
-  {
-    return motor_->handleHalt();
-  }
-  else
-  {
-    return false;
-  }
-}
-
-template <class NODETYPE>
-bool NodeCanopen402Driver<NODETYPE>::set_operation_mode(uint16_t mode)
-{
-  if (this->activated_.load())
-  {
-    if (motor_->getMode() != mode)
+    if (channel >= motors_.size())
     {
-      return motor_->enterModeAndWait(mode);
+      RCLCPP_ERROR(this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+      return false;
+    }
+    return motors_[channel]->handleRecover();
+  }
+  else
+  {
+    return false;
+  }
+}
+
+template <class NODETYPE>
+bool NodeCanopen402Driver<NODETYPE>::halt_motor(uint8_t channel)
+{
+  if (this->activated_.load())
+  {
+    if (channel >= motors_.size())
+    {
+      RCLCPP_ERROR(this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+      return false;
+    }
+    return motors_[channel]->handleHalt();
+  }
+  else
+  {
+    return false;
+  }
+}
+
+template <class NODETYPE>
+bool NodeCanopen402Driver<NODETYPE>::set_operation_mode(uint16_t mode, uint8_t channel)
+{
+  if (this->activated_.load())
+  {
+    if (channel >= motors_.size())
+    {
+      RCLCPP_ERROR(this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+      return false;
+    }
+
+    if (motors_[channel]->getMode() != mode)
+    {
+      return motors_[channel]->enterModeAndWait(mode);
     }
     else
     {
@@ -649,30 +803,45 @@ bool NodeCanopen402Driver<NODETYPE>::set_operation_mode(uint16_t mode)
 }
 
 template <class NODETYPE>
-bool NodeCanopen402Driver<NODETYPE>::set_target(double target)
+bool NodeCanopen402Driver<NODETYPE>::set_target(double target, uint8_t channel)
 {
   if (this->activated_.load())
   {
-    auto mode = motor_->getMode();
+    if (channel >= motors_.size())
+    {
+      RCLCPP_ERROR(this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+      return false;
+    }
+
+    auto mode = motors_[channel]->getMode();
+
+    // Get per-channel scales/offsets (or use global as fallback)
+    double scale_pos_to_dev = (channel < channel_scale_pos_to_dev_.size()) ?
+                          channel_scale_pos_to_dev_[channel] : scale_pos_to_dev_;
+    double offset_pos_to_dev = (channel < channel_offset_pos_to_dev_.size()) ?
+                           channel_offset_pos_to_dev_[channel] : offset_pos_to_dev_;
+    double scale_vel_to_dev = (channel < channel_scale_vel_to_dev_.size()) ?
+                          channel_scale_vel_to_dev_[channel] : scale_vel_to_dev_;
+
     double scaled_target;
     if (
       (mode == MotorBase::Profiled_Position) or (mode == MotorBase::Cyclic_Synchronous_Position) or
       (mode == MotorBase::Interpolated_Position))
     {
-      scaled_target = target * scale_pos_to_dev_ + offset_pos_to_dev_;
+      scaled_target = target * scale_pos_to_dev + offset_pos_to_dev;
     }
     else if (
       (mode == MotorBase::Velocity) or (mode == MotorBase::Profiled_Velocity) or
       (mode == MotorBase::Cyclic_Synchronous_Velocity))
     {
-      scaled_target = target * scale_vel_to_dev_;
+      scaled_target = target * scale_vel_to_dev;
     }
     else
     {
       scaled_target = target;
     }
-    // RCLCPP_INFO(this->node_->get_logger(), "Scaled target %f", scaled_target);
-    return motor_->setTarget(scaled_target);
+
+    return motors_[channel]->setTarget(scaled_target);
   }
   else
   {
@@ -684,7 +853,11 @@ template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::diagnostic_callback(
   diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
-  this->motor_->handleDiag();
+  // Handle diagnostics for all motors
+  for (size_t ch = 0; ch < motors_.size(); ++ch)
+  {
+    motors_[ch]->handleDiag();
+  }
 
   stat.summary(this->diagnostic_collector_->getLevel(), this->diagnostic_collector_->getMessage());
   stat.add("device_state", this->diagnostic_collector_->getValue("DEVICE"));
@@ -692,6 +865,14 @@ void NodeCanopen402Driver<NODETYPE>::diagnostic_callback(
   stat.add("emcy_state", this->diagnostic_collector_->getValue("EMCY"));
   stat.add("cia402_mode", this->diagnostic_collector_->getValue("cia402_mode"));
   stat.add("cia402_state", this->diagnostic_collector_->getValue("cia402_state"));
+
+  // Add per-channel diagnostic info
+  for (size_t ch = 0; ch < motors_.size(); ++ch)
+  {
+    std::string ch_prefix = "ch" + std::to_string(ch) + "_";
+    stat.add(ch_prefix + "mode", this->diagnostic_collector_->getValue((ch_prefix + "cia402_mode").c_str()));
+    stat.add(ch_prefix + "state", this->diagnostic_collector_->getValue((ch_prefix + "cia402_state").c_str()));
+  }
 }
 
 #endif

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -62,20 +62,8 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::init(bool called_fro
 template <class NODETYPE>
 void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
 {
-  // Resize service vectors
-  handle_init_services_.resize(num_channels_);
-  handle_enable_services_.resize(num_channels_);
-  handle_disable_services_.resize(num_channels_);
-  handle_halt_services_.resize(num_channels_);
-  handle_recover_services_.resize(num_channels_);
-  handle_set_mode_position_services_.resize(num_channels_);
-  handle_set_mode_torque_services_.resize(num_channels_);
-  handle_set_mode_velocity_services_.resize(num_channels_);
-  handle_set_mode_cyclic_velocity_services_.resize(num_channels_);
-  handle_set_mode_cyclic_position_services_.resize(num_channels_);
-  handle_set_mode_cyclic_torque_services_.resize(num_channels_);
-  handle_set_mode_interpolated_position_services_.resize(num_channels_);
-  handle_set_target_services_.resize(num_channels_);
+  // Ensure per-channel storage exists
+  channels_.resize(num_channels_);
 
   // Create services for each channel
   for (uint8_t ch = 0; ch < num_channels_; ++ch)
@@ -104,42 +92,42 @@ void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
     }
 
     // Init service
-    handle_init_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+    channels_[ch].handle_init = this->node_->template create_service<std_srvs::srv::Trigger>(
       service_prefix + "init", [this, ch](
                                  const std_srvs::srv::Trigger::Request::SharedPtr request,
                                  std_srvs::srv::Trigger::Response::SharedPtr response)
       { this->handle_init(request, response, ch); });
 
     // Enable service
-    handle_enable_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+    channels_[ch].handle_enable = this->node_->template create_service<std_srvs::srv::Trigger>(
       service_prefix + "enable", [this, ch](
                                    const std_srvs::srv::Trigger::Request::SharedPtr request,
                                    std_srvs::srv::Trigger::Response::SharedPtr response)
       { this->handle_enable(request, response, ch); });
 
     // Disable service
-    handle_disable_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+    channels_[ch].handle_disable = this->node_->template create_service<std_srvs::srv::Trigger>(
       service_prefix + "disable", [this, ch](
                                     const std_srvs::srv::Trigger::Request::SharedPtr request,
                                     std_srvs::srv::Trigger::Response::SharedPtr response)
       { this->handle_disable(request, response, ch); });
 
     // Halt service
-    handle_halt_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+    channels_[ch].handle_halt = this->node_->template create_service<std_srvs::srv::Trigger>(
       service_prefix + "halt", [this, ch](
                                  const std_srvs::srv::Trigger::Request::SharedPtr request,
                                  std_srvs::srv::Trigger::Response::SharedPtr response)
       { this->handle_halt(request, response, ch); });
 
     // Recover service
-    handle_recover_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
+    channels_[ch].handle_recover = this->node_->template create_service<std_srvs::srv::Trigger>(
       service_prefix + "recover", [this, ch](
                                     const std_srvs::srv::Trigger::Request::SharedPtr request,
                                     std_srvs::srv::Trigger::Response::SharedPtr response)
       { this->handle_recover(request, response, ch); });
 
     // Position mode service
-    handle_set_mode_position_services_[ch] =
+    channels_[ch].handle_set_mode_position =
       this->node_->template create_service<std_srvs::srv::Trigger>(
         service_prefix + "position_mode",
         [this, ch](
@@ -148,7 +136,7 @@ void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
         { this->handle_set_mode_position(request, response, ch); });
 
     // Velocity mode service
-    handle_set_mode_velocity_services_[ch] =
+    channels_[ch].handle_set_mode_velocity =
       this->node_->template create_service<std_srvs::srv::Trigger>(
         service_prefix + "velocity_mode",
         [this, ch](
@@ -157,7 +145,7 @@ void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
         { this->handle_set_mode_velocity(request, response, ch); });
 
     // Torque mode service
-    handle_set_mode_torque_services_[ch] =
+    channels_[ch].handle_set_mode_torque =
       this->node_->template create_service<std_srvs::srv::Trigger>(
         service_prefix + "torque_mode", [this, ch](
                                           const std_srvs::srv::Trigger::Request::SharedPtr request,
@@ -165,7 +153,7 @@ void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
         { this->handle_set_mode_torque(request, response, ch); });
 
     // Cyclic velocity mode service
-    handle_set_mode_cyclic_velocity_services_[ch] =
+    channels_[ch].handle_set_mode_cyclic_velocity =
       this->node_->template create_service<std_srvs::srv::Trigger>(
         service_prefix + "cyclic_velocity_mode",
         [this, ch](
@@ -174,7 +162,7 @@ void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
         { this->handle_set_mode_cyclic_velocity(request, response, ch); });
 
     // Cyclic position mode service
-    handle_set_mode_cyclic_position_services_[ch] =
+    channels_[ch].handle_set_mode_cyclic_position =
       this->node_->template create_service<std_srvs::srv::Trigger>(
         service_prefix + "cyclic_position_mode",
         [this, ch](
@@ -183,7 +171,7 @@ void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
         { this->handle_set_mode_cyclic_position(request, response, ch); });
 
     // Cyclic torque mode service
-    handle_set_mode_cyclic_torque_services_[ch] =
+    channels_[ch].handle_set_mode_cyclic_torque =
       this->node_->template create_service<std_srvs::srv::Trigger>(
         service_prefix + "cyclic_torque_mode",
         [this, ch](
@@ -192,7 +180,7 @@ void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
         { this->handle_set_mode_cyclic_torque(request, response, ch); });
 
     // Interpolated position mode service
-    handle_set_mode_interpolated_position_services_[ch] =
+    channels_[ch].handle_set_mode_interpolated_position =
       this->node_->template create_service<std_srvs::srv::Trigger>(
         service_prefix + "interpolated_position_mode",
         [this, ch](
@@ -201,7 +189,7 @@ void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
         { this->handle_set_mode_interpolated_position(request, response, ch); });
 
     // Target service (uses COTargetDouble without channel field, since channel is in service name)
-    handle_set_target_services_[ch] =
+    channels_[ch].handle_set_target =
       this->node_->template create_service<canopen_interfaces::srv::COTargetDouble>(
         service_prefix + "target",
         [this, ch](
@@ -312,6 +300,7 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
   }
 
   // Parse channel names
+  channel_names_.clear();
   try
   {
     auto names_node = this->config_["channel_names"];
@@ -336,7 +325,20 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
     }
   }
 
-  // Parse per-channel scales/offsets
+  // Resolve per-channel scales/offsets into per-channel contexts
+  channels_.clear();
+  channels_.resize(num_channels_);
+  for (uint8_t i = 0; i < num_channels_; ++i)
+  {
+    channels_[i].scale_pos_to_dev = scale_pos_to_dev_;
+    channels_[i].scale_pos_from_dev = scale_pos_from_dev_;
+    channels_[i].scale_vel_to_dev = scale_vel_to_dev_;
+    channels_[i].scale_vel_from_dev = scale_vel_from_dev_;
+    channels_[i].scale_eff_from_dev = scale_eff_from_dev_;
+    channels_[i].offset_pos_to_dev = offset_pos_to_dev_;
+    channels_[i].offset_pos_from_dev = offset_pos_from_dev_;
+  }
+
   try
   {
     auto channels_node = this->config_["channels"];
@@ -347,59 +349,52 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
         auto ch = channels_node[i];
         try
         {
-          channel_scale_pos_to_dev_.push_back(ch["scale_pos_to_dev"].as<double>());
+          channels_[i].scale_pos_to_dev = ch["scale_pos_to_dev"].as<double>();
         }
         catch (...)
         {
-          channel_scale_pos_to_dev_.push_back(scale_pos_to_dev_);
         }
         try
         {
-          channel_scale_pos_from_dev_.push_back(ch["scale_pos_from_dev"].as<double>());
+          channels_[i].scale_pos_from_dev = ch["scale_pos_from_dev"].as<double>();
         }
         catch (...)
         {
-          channel_scale_pos_from_dev_.push_back(scale_pos_from_dev_);
         }
         try
         {
-          channel_scale_vel_to_dev_.push_back(ch["scale_vel_to_dev"].as<double>());
+          channels_[i].scale_vel_to_dev = ch["scale_vel_to_dev"].as<double>();
         }
         catch (...)
         {
-          channel_scale_vel_to_dev_.push_back(scale_vel_to_dev_);
         }
         try
         {
-          channel_scale_vel_from_dev_.push_back(ch["scale_vel_from_dev"].as<double>());
+          channels_[i].scale_vel_from_dev = ch["scale_vel_from_dev"].as<double>();
         }
         catch (...)
         {
-          channel_scale_vel_from_dev_.push_back(scale_vel_from_dev_);
         }
         try
         {
-          channel_scale_eff_from_dev_.push_back(ch["scale_eff_from_dev"].as<double>());
+          channels_[i].scale_eff_from_dev = ch["scale_eff_from_dev"].as<double>();
         }
         catch (...)
         {
-          channel_scale_eff_from_dev_.push_back(scale_eff_from_dev_);
         }
         try
         {
-          channel_offset_pos_to_dev_.push_back(ch["offset_pos_to_dev"].as<double>());
+          channels_[i].offset_pos_to_dev = ch["offset_pos_to_dev"].as<double>();
         }
         catch (...)
         {
-          channel_offset_pos_to_dev_.push_back(offset_pos_to_dev_);
         }
         try
         {
-          channel_offset_pos_from_dev_.push_back(ch["offset_pos_from_dev"].as<double>());
+          channels_[i].offset_pos_from_dev = ch["offset_pos_from_dev"].as<double>();
         }
         catch (...)
         {
-          channel_offset_pos_from_dev_.push_back(offset_pos_from_dev_);
         }
       }
     }
@@ -522,6 +517,7 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
   }
 
   // Parse channel names
+  channel_names_.clear();
   try
   {
     auto names_node = this->config_["channel_names"];
@@ -546,7 +542,20 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
     }
   }
 
-  // Parse per-channel scales/offsets
+  // Resolve per-channel scales/offsets into per-channel contexts
+  channels_.clear();
+  channels_.resize(num_channels_);
+  for (uint8_t i = 0; i < num_channels_; ++i)
+  {
+    channels_[i].scale_pos_to_dev = scale_pos_to_dev_;
+    channels_[i].scale_pos_from_dev = scale_pos_from_dev_;
+    channels_[i].scale_vel_to_dev = scale_vel_to_dev_;
+    channels_[i].scale_vel_from_dev = scale_vel_from_dev_;
+    channels_[i].scale_eff_from_dev = scale_eff_from_dev_;
+    channels_[i].offset_pos_to_dev = offset_pos_to_dev_;
+    channels_[i].offset_pos_from_dev = offset_pos_from_dev_;
+  }
+
   try
   {
     auto channels_node = this->config_["channels"];
@@ -557,59 +566,52 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
         auto ch = channels_node[i];
         try
         {
-          channel_scale_pos_to_dev_.push_back(ch["scale_pos_to_dev"].as<double>());
+          channels_[i].scale_pos_to_dev = ch["scale_pos_to_dev"].as<double>();
         }
         catch (...)
         {
-          channel_scale_pos_to_dev_.push_back(scale_pos_to_dev_);
         }
         try
         {
-          channel_scale_pos_from_dev_.push_back(ch["scale_pos_from_dev"].as<double>());
+          channels_[i].scale_pos_from_dev = ch["scale_pos_from_dev"].as<double>();
         }
         catch (...)
         {
-          channel_scale_pos_from_dev_.push_back(scale_pos_from_dev_);
         }
         try
         {
-          channel_scale_vel_to_dev_.push_back(ch["scale_vel_to_dev"].as<double>());
+          channels_[i].scale_vel_to_dev = ch["scale_vel_to_dev"].as<double>();
         }
         catch (...)
         {
-          channel_scale_vel_to_dev_.push_back(scale_vel_to_dev_);
         }
         try
         {
-          channel_scale_vel_from_dev_.push_back(ch["scale_vel_from_dev"].as<double>());
+          channels_[i].scale_vel_from_dev = ch["scale_vel_from_dev"].as<double>();
         }
         catch (...)
         {
-          channel_scale_vel_from_dev_.push_back(scale_vel_from_dev_);
         }
         try
         {
-          channel_scale_eff_from_dev_.push_back(ch["scale_eff_from_dev"].as<double>());
+          channels_[i].scale_eff_from_dev = ch["scale_eff_from_dev"].as<double>();
         }
         catch (...)
         {
-          channel_scale_eff_from_dev_.push_back(scale_eff_from_dev_);
         }
         try
         {
-          channel_offset_pos_to_dev_.push_back(ch["offset_pos_to_dev"].as<double>());
+          channels_[i].offset_pos_to_dev = ch["offset_pos_to_dev"].as<double>();
         }
         catch (...)
         {
-          channel_offset_pos_to_dev_.push_back(offset_pos_to_dev_);
         }
         try
         {
-          channel_offset_pos_from_dev_.push_back(ch["offset_pos_from_dev"].as<double>());
+          channels_[i].offset_pos_from_dev = ch["offset_pos_from_dev"].as<double>();
         }
         catch (...)
         {
-          channel_offset_pos_from_dev_.push_back(offset_pos_from_dev_);
         }
       }
     }
@@ -636,10 +638,11 @@ void NodeCanopen402Driver<NODETYPE>::activate(bool called_from_base)
 {
   NodeCanopenProxyDriver<NODETYPE>::activate(false);
   // Register default modes for all motor instances
-  for (auto & motor : motors_)
+  for (auto & ch : channels_)
   {
-    motor->registerDefaultModes();
-    motor->set_diagnostic_status_msgs(this->diagnostic_collector_, this->diagnostic_enabled_);
+    if (!ch.motor) continue;
+    ch.motor->registerDefaultModes();
+    ch.motor->set_diagnostic_status_msgs(this->diagnostic_collector_, this->diagnostic_enabled_);
   }
 }
 
@@ -655,10 +658,11 @@ void NodeCanopen402Driver<NODETYPE>::poll_timer_callback()
 {
   NodeCanopenProxyDriver<NODETYPE>::poll_timer_callback();
   // Handle read/write for all motors
-  for (auto & motor : motors_)
+  for (auto & ch : channels_)
   {
-    motor->handleRead();
-    motor->handleWrite();
+    if (!ch.motor) continue;
+    ch.motor->handleRead();
+    ch.motor->handleWrite();
   }
   publish();
 }
@@ -668,7 +672,7 @@ void NodeCanopen402Driver<NODETYPE>::publish()
 {
   sensor_msgs::msg::JointState js_msg;
   // Publish joint state for all channels
-  for (size_t ch = 0; ch < motors_.size(); ++ch)
+  for (size_t ch = 0; ch < channels_.size(); ++ch)
   {
     std::string name;
     if (num_channels_ == 1)
@@ -690,23 +694,20 @@ void NodeCanopen402Driver<NODETYPE>::publish()
       }
     }
 
-    double scale_pos_from_dev = (ch < channel_scale_pos_from_dev_.size())
-                                  ? channel_scale_pos_from_dev_[ch]
-                                  : scale_pos_from_dev_;
-    double offset_pos_from_dev = (ch < channel_offset_pos_from_dev_.size())
-                                   ? channel_offset_pos_from_dev_[ch]
-                                   : offset_pos_from_dev_;
-    double scale_vel_from_dev = (ch < channel_scale_vel_from_dev_.size())
-                                  ? channel_scale_vel_from_dev_[ch]
-                                  : scale_vel_from_dev_;
-    double scale_eff_from_dev = (ch < channel_scale_eff_from_dev_.size())
-                                  ? channel_scale_eff_from_dev_[ch]
-                                  : scale_eff_from_dev_;
     js_msg.name.push_back(name);
+    if (!channels_[ch].motor)
+    {
+      js_msg.position.push_back(0.0);
+      js_msg.velocity.push_back(0.0);
+      js_msg.effort.push_back(0.0);
+      continue;
+    }
+
     js_msg.position.push_back(
-      motors_[ch]->get_position() * scale_pos_from_dev + offset_pos_from_dev);
-    js_msg.velocity.push_back(motors_[ch]->get_speed() * scale_vel_from_dev);
-    js_msg.effort.push_back(motors_[ch]->get_effort() * scale_eff_from_dev);
+      channels_[ch].motor->get_position() * channels_[ch].scale_pos_from_dev +
+      channels_[ch].offset_pos_from_dev);
+    js_msg.velocity.push_back(channels_[ch].motor->get_speed() * channels_[ch].scale_vel_from_dev);
+    js_msg.effort.push_back(channels_[ch].motor->get_effort() * channels_[ch].scale_eff_from_dev);
   }
   publish_joint_state->publish(js_msg);
 }
@@ -716,11 +717,11 @@ void NodeCanopen402Driver<NODETYPE>::add_to_master()
 {
   NodeCanopenProxyDriver<NODETYPE>::add_to_master();
   // Create separate Motor402 instance for each channel
-  motors_.clear();
+  channels_.resize(num_channels_);
   for (uint8_t ch = 0; ch < num_channels_; ++ch)
   {
-    motors_.push_back(std::make_shared<Motor402>(
-      this->lely_driver_, switching_state_, homing_timeout_seconds_, ch));
+    channels_[ch].motor =
+      std::make_shared<Motor402>(this->lely_driver_, switching_state_, homing_timeout_seconds_, ch);
   }
 }
 
@@ -815,7 +816,12 @@ void NodeCanopen402Driver<NODETYPE>::handle_disable(
 {
   if (this->activated_.load())
   {
-    response->success = motors_[channel]->handleDisable();
+    if (channel >= channels_.size() || !channels_[channel].motor)
+    {
+      response->success = false;
+      return;
+    }
+    response->success = channels_[channel].motor->handleDisable();
   }
   else
   {
@@ -830,7 +836,12 @@ void NodeCanopen402Driver<NODETYPE>::handle_enable(
 {
   if (this->activated_.load())
   {
-    response->success = motors_[channel]->handleEnable();
+    if (channel >= channels_.size() || !channels_[channel].motor)
+    {
+      response->success = false;
+      return;
+    }
+    response->success = channels_[channel].motor->handleEnable();
   }
   else
   {
@@ -843,13 +854,14 @@ bool NodeCanopen402Driver<NODETYPE>::init_motor(uint8_t channel)
 {
   if (this->activated_.load())
   {
-    if (channel >= motors_.size())
+    if (channel >= channels_.size())
     {
       RCLCPP_ERROR(
-        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, channels_.size() - 1);
       return false;
     }
-    return motors_[channel]->handleInit();
+    if (!channels_[channel].motor) return false;
+    return channels_[channel].motor->handleInit();
   }
   else
   {
@@ -863,13 +875,14 @@ bool NodeCanopen402Driver<NODETYPE>::recover_motor(uint8_t channel)
 {
   if (this->activated_.load())
   {
-    if (channel >= motors_.size())
+    if (channel >= channels_.size())
     {
       RCLCPP_ERROR(
-        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, channels_.size() - 1);
       return false;
     }
-    return motors_[channel]->handleRecover();
+    if (!channels_[channel].motor) return false;
+    return channels_[channel].motor->handleRecover();
   }
   else
   {
@@ -882,13 +895,14 @@ bool NodeCanopen402Driver<NODETYPE>::halt_motor(uint8_t channel)
 {
   if (this->activated_.load())
   {
-    if (channel >= motors_.size())
+    if (channel >= channels_.size())
     {
       RCLCPP_ERROR(
-        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, channels_.size() - 1);
       return false;
     }
-    return motors_[channel]->handleHalt();
+    if (!channels_[channel].motor) return false;
+    return channels_[channel].motor->handleHalt();
   }
   else
   {
@@ -901,16 +915,18 @@ bool NodeCanopen402Driver<NODETYPE>::set_operation_mode(uint16_t mode, uint8_t c
 {
   if (this->activated_.load())
   {
-    if (channel >= motors_.size())
+    if (channel >= channels_.size())
     {
       RCLCPP_ERROR(
-        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, channels_.size() - 1);
       return false;
     }
 
-    if (motors_[channel]->getMode() != mode)
+    if (!channels_[channel].motor) return false;
+
+    if (channels_[channel].motor->getMode() != mode)
     {
-      return motors_[channel]->enterModeAndWait(mode);
+      return channels_[channel].motor->enterModeAndWait(mode);
     }
     else
     {
@@ -925,25 +941,20 @@ bool NodeCanopen402Driver<NODETYPE>::set_target(double target, uint8_t channel)
 {
   if (this->activated_.load())
   {
-    if (channel >= motors_.size())
+    if (channel >= channels_.size())
     {
       RCLCPP_ERROR(
-        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, channels_.size() - 1);
       return false;
     }
 
-    auto mode = motors_[channel]->getMode();
+    if (!channels_[channel].motor) return false;
 
-    // Get per-channel scales/offsets (or use global as fallback)
-    double scale_pos_to_dev = (channel < channel_scale_pos_to_dev_.size())
-                                ? channel_scale_pos_to_dev_[channel]
-                                : scale_pos_to_dev_;
-    double offset_pos_to_dev = (channel < channel_offset_pos_to_dev_.size())
-                                 ? channel_offset_pos_to_dev_[channel]
-                                 : offset_pos_to_dev_;
-    double scale_vel_to_dev = (channel < channel_scale_vel_to_dev_.size())
-                                ? channel_scale_vel_to_dev_[channel]
-                                : scale_vel_to_dev_;
+    auto mode = channels_[channel].motor->getMode();
+
+    const double scale_pos_to_dev = channels_[channel].scale_pos_to_dev;
+    const double offset_pos_to_dev = channels_[channel].offset_pos_to_dev;
+    const double scale_vel_to_dev = channels_[channel].scale_vel_to_dev;
 
     double scaled_target;
     if (
@@ -963,7 +974,7 @@ bool NodeCanopen402Driver<NODETYPE>::set_target(double target, uint8_t channel)
       scaled_target = target;
     }
 
-    return motors_[channel]->setTarget(scaled_target);
+    return channels_[channel].motor->setTarget(scaled_target);
   }
   else
   {
@@ -976,9 +987,10 @@ void NodeCanopen402Driver<NODETYPE>::diagnostic_callback(
   diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   // Handle diagnostics for all motors
-  for (size_t ch = 0; ch < motors_.size(); ++ch)
+  for (size_t ch = 0; ch < channels_.size(); ++ch)
   {
-    motors_[ch]->handleDiag();
+    if (!channels_[ch].motor) continue;
+    channels_[ch].motor->handleDiag();
   }
 
   stat.summary(this->diagnostic_collector_->getLevel(), this->diagnostic_collector_->getMessage());
@@ -989,7 +1001,7 @@ void NodeCanopen402Driver<NODETYPE>::diagnostic_callback(
   stat.add("cia402_state", this->diagnostic_collector_->getValue("cia402_state"));
 
   // Add per-channel diagnostic info
-  for (size_t ch = 0; ch < motors_.size(); ++ch)
+  for (size_t ch = 0; ch < channels_.size(); ++ch)
   {
     std::string ch_prefix = "ch" + std::to_string(ch) + "_";
     stat.add(

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -199,10 +199,10 @@ void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
   }
 }
 
-template <>
-void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool called_from_base)
+template <class NODETYPE>
+void NodeCanopen402Driver<NODETYPE>::configure_common()
 {
-  NodeCanopenProxyDriver<rclcpp_lifecycle::LifecycleNode>::configure(false);
+  NodeCanopenProxyDriver<NODETYPE>::configure(false);
   std::optional<double> scale_pos_to_dev;
   std::optional<double> scale_pos_from_dev;
   std::optional<double> scale_vel_to_dev;
@@ -214,70 +214,69 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
   std::optional<int> homing_timeout_seconds;
   try
   {
-    scale_pos_to_dev = std::optional(this->config_["scale_pos_to_dev"].as<double>());
+    scale_pos_to_dev = std::optional(this->config_["scale_pos_to_dev"].template as<double>());
   }
   catch (...)
   {
   }
   try
   {
-    scale_pos_from_dev = std::optional(this->config_["scale_pos_from_dev"].as<double>());
+    scale_pos_from_dev = std::optional(this->config_["scale_pos_from_dev"].template as<double>());
   }
   catch (...)
   {
   }
   try
   {
-    scale_vel_to_dev = std::optional(this->config_["scale_vel_to_dev"].as<double>());
+    scale_vel_to_dev = std::optional(this->config_["scale_vel_to_dev"].template as<double>());
   }
   catch (...)
   {
   }
   try
   {
-    scale_vel_from_dev = std::optional(this->config_["scale_vel_from_dev"].as<double>());
+    scale_vel_from_dev = std::optional(this->config_["scale_vel_from_dev"].template as<double>());
   }
   catch (...)
   {
   }
   try
   {
-    scale_eff_from_dev = std::optional(this->config_["scale_eff_from_dev"].as<double>());
+    scale_eff_from_dev = std::optional(this->config_["scale_eff_from_dev"].template as<double>());
   }
   catch (...)
   {
   }
   try
   {
-    offset_pos_to_dev = std::optional(this->config_["offset_pos_to_dev"].as<double>());
+    offset_pos_to_dev = std::optional(this->config_["offset_pos_to_dev"].template as<double>());
   }
   catch (...)
   {
   }
   try
   {
-    offset_pos_from_dev = std::optional(this->config_["offset_pos_from_dev"].as<double>());
+    offset_pos_from_dev = std::optional(this->config_["offset_pos_from_dev"].template as<double>());
   }
   catch (...)
   {
   }
   try
   {
-    switching_state = std::optional(this->config_["switching_state"].as<int>());
+    switching_state = std::optional(this->config_["switching_state"].template as<int>());
   }
   catch (...)
   {
   }
   try
   {
-    homing_timeout_seconds = std::optional(this->config_["homing_timeout_seconds"].as<int>());
+    homing_timeout_seconds =
+      std::optional(this->config_["homing_timeout_seconds"].template as<int>());
   }
   catch (...)
   {
   }
 
-  // auto period = this->config_["scale_eff_to_dev"].as<double>();
-  // auto period = this->config_["scale_eff_from_dev"].as<double>();
   scale_pos_to_dev_ = scale_pos_to_dev.value_or(1000.0);
   scale_pos_from_dev_ = scale_pos_from_dev.value_or(0.001);
   scale_vel_to_dev_ = scale_vel_to_dev.value_or(1000.0);
@@ -293,7 +292,7 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
   num_channels_ = 1;
   try
   {
-    num_channels_ = this->config_["num_channels"].as<uint8_t>();
+    num_channels_ = this->config_["num_channels"].template as<uint8_t>();
   }
   catch (...)
   {
@@ -308,7 +307,7 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
     {
       for (size_t i = 0; i < names_node.size(); ++i)
       {
-        channel_names_.push_back(names_node[i].as<std::string>());
+        channel_names_.push_back(names_node[i].template as<std::string>());
       }
     }
   }
@@ -349,49 +348,49 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
         auto ch = channels_node[i];
         try
         {
-          channels_[i].scale_pos_to_dev = ch["scale_pos_to_dev"].as<double>();
+          channels_[i].scale_pos_to_dev = ch["scale_pos_to_dev"].template as<double>();
         }
         catch (...)
         {
         }
         try
         {
-          channels_[i].scale_pos_from_dev = ch["scale_pos_from_dev"].as<double>();
+          channels_[i].scale_pos_from_dev = ch["scale_pos_from_dev"].template as<double>();
         }
         catch (...)
         {
         }
         try
         {
-          channels_[i].scale_vel_to_dev = ch["scale_vel_to_dev"].as<double>();
+          channels_[i].scale_vel_to_dev = ch["scale_vel_to_dev"].template as<double>();
         }
         catch (...)
         {
         }
         try
         {
-          channels_[i].scale_vel_from_dev = ch["scale_vel_from_dev"].as<double>();
+          channels_[i].scale_vel_from_dev = ch["scale_vel_from_dev"].template as<double>();
         }
         catch (...)
         {
         }
         try
         {
-          channels_[i].scale_eff_from_dev = ch["scale_eff_from_dev"].as<double>();
+          channels_[i].scale_eff_from_dev = ch["scale_eff_from_dev"].template as<double>();
         }
         catch (...)
         {
         }
         try
         {
-          channels_[i].offset_pos_to_dev = ch["offset_pos_to_dev"].as<double>();
+          channels_[i].offset_pos_to_dev = ch["offset_pos_to_dev"].template as<double>();
         }
         catch (...)
         {
         }
         try
         {
-          channels_[i].offset_pos_from_dev = ch["offset_pos_from_dev"].as<double>();
+          channels_[i].offset_pos_from_dev = ch["offset_pos_from_dev"].template as<double>();
         }
         catch (...)
         {
@@ -417,220 +416,15 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
 }
 
 template <>
+void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool called_from_base)
+{
+  this->configure_common();
+}
+
+template <>
 void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
 {
-  NodeCanopenProxyDriver<rclcpp::Node>::configure(false);
-  std::optional<double> scale_pos_to_dev;
-  std::optional<double> scale_pos_from_dev;
-  std::optional<double> scale_vel_to_dev;
-  std::optional<double> scale_vel_from_dev;
-  std::optional<double> scale_eff_from_dev;
-  std::optional<double> offset_pos_to_dev;
-  std::optional<double> offset_pos_from_dev;
-  std::optional<int> switching_state;
-  std::optional<int> homing_timeout_seconds;
-  try
-  {
-    scale_pos_to_dev = std::optional(this->config_["scale_pos_to_dev"].as<double>());
-  }
-  catch (...)
-  {
-  }
-  try
-  {
-    scale_pos_from_dev = std::optional(this->config_["scale_pos_from_dev"].as<double>());
-  }
-  catch (...)
-  {
-  }
-  try
-  {
-    scale_vel_to_dev = std::optional(this->config_["scale_vel_to_dev"].as<double>());
-  }
-  catch (...)
-  {
-  }
-  try
-  {
-    scale_vel_from_dev = std::optional(this->config_["scale_vel_from_dev"].as<double>());
-  }
-  catch (...)
-  {
-  }
-  try
-  {
-    scale_eff_from_dev = std::optional(this->config_["scale_eff_from_dev"].as<double>());
-  }
-  catch (...)
-  {
-  }
-  try
-  {
-    offset_pos_to_dev = std::optional(this->config_["offset_pos_to_dev"].as<double>());
-  }
-  catch (...)
-  {
-  }
-  try
-  {
-    offset_pos_from_dev = std::optional(this->config_["offset_pos_from_dev"].as<double>());
-  }
-  catch (...)
-  {
-  }
-  try
-  {
-    switching_state = std::optional(this->config_["switching_state"].as<int>());
-  }
-  catch (...)
-  {
-  }
-  try
-  {
-    homing_timeout_seconds = std::optional(this->config_["homing_timeout_seconds"].as<int>());
-  }
-  catch (...)
-  {
-  }
-
-  // auto period = this->config_["scale_eff_to_dev"].as<double>();
-  // auto period = this->config_["scale_eff_from_dev"].as<double>();
-  scale_pos_to_dev_ = scale_pos_to_dev.value_or(1000.0);
-  scale_pos_from_dev_ = scale_pos_from_dev.value_or(0.001);
-  scale_vel_to_dev_ = scale_vel_to_dev.value_or(1000.0);
-  scale_vel_from_dev_ = scale_vel_from_dev.value_or(0.001);
-  scale_eff_from_dev_ = scale_eff_from_dev.value_or(0.001);
-  offset_pos_to_dev_ = offset_pos_to_dev.value_or(0.0);
-  offset_pos_from_dev_ = offset_pos_from_dev.value_or(0.0);
-  switching_state_ = (ros2_canopen::State402::InternalState)switching_state.value_or(
-    (int)ros2_canopen::State402::InternalState::Operation_Enable);
-  homing_timeout_seconds_ = homing_timeout_seconds.value_or(10);
-
-  // Multi-channel configuration
-  num_channels_ = 1;
-  try
-  {
-    num_channels_ = this->config_["num_channels"].as<uint8_t>();
-  }
-  catch (...)
-  {
-  }
-
-  // Parse channel names
-  channel_names_.clear();
-  try
-  {
-    auto names_node = this->config_["channel_names"];
-    if (names_node.IsDefined() && names_node.IsSequence())
-    {
-      for (size_t i = 0; i < names_node.size(); ++i)
-      {
-        channel_names_.push_back(names_node[i].as<std::string>());
-      }
-    }
-  }
-  catch (...)
-  {
-  }
-
-  // Generate default names if not provided
-  if (channel_names_.empty())
-  {
-    for (uint8_t i = 0; i < num_channels_; ++i)
-    {
-      channel_names_.push_back(std::string(this->node_->get_name()) + "/" + std::to_string(i));
-    }
-  }
-
-  // Resolve per-channel scales/offsets into per-channel contexts
-  channels_.clear();
-  channels_.resize(num_channels_);
-  for (uint8_t i = 0; i < num_channels_; ++i)
-  {
-    channels_[i].scale_pos_to_dev = scale_pos_to_dev_;
-    channels_[i].scale_pos_from_dev = scale_pos_from_dev_;
-    channels_[i].scale_vel_to_dev = scale_vel_to_dev_;
-    channels_[i].scale_vel_from_dev = scale_vel_from_dev_;
-    channels_[i].scale_eff_from_dev = scale_eff_from_dev_;
-    channels_[i].offset_pos_to_dev = offset_pos_to_dev_;
-    channels_[i].offset_pos_from_dev = offset_pos_from_dev_;
-  }
-
-  try
-  {
-    auto channels_node = this->config_["channels"];
-    if (channels_node.IsDefined() && channels_node.IsSequence())
-    {
-      for (size_t i = 0; i < channels_node.size() && i < num_channels_; ++i)
-      {
-        auto ch = channels_node[i];
-        try
-        {
-          channels_[i].scale_pos_to_dev = ch["scale_pos_to_dev"].as<double>();
-        }
-        catch (...)
-        {
-        }
-        try
-        {
-          channels_[i].scale_pos_from_dev = ch["scale_pos_from_dev"].as<double>();
-        }
-        catch (...)
-        {
-        }
-        try
-        {
-          channels_[i].scale_vel_to_dev = ch["scale_vel_to_dev"].as<double>();
-        }
-        catch (...)
-        {
-        }
-        try
-        {
-          channels_[i].scale_vel_from_dev = ch["scale_vel_from_dev"].as<double>();
-        }
-        catch (...)
-        {
-        }
-        try
-        {
-          channels_[i].scale_eff_from_dev = ch["scale_eff_from_dev"].as<double>();
-        }
-        catch (...)
-        {
-        }
-        try
-        {
-          channels_[i].offset_pos_to_dev = ch["offset_pos_to_dev"].as<double>();
-        }
-        catch (...)
-        {
-        }
-        try
-        {
-          channels_[i].offset_pos_from_dev = ch["offset_pos_from_dev"].as<double>();
-        }
-        catch (...)
-        {
-        }
-      }
-    }
-  }
-  catch (...)
-  {
-  }
-
-  RCLCPP_INFO(
-    this->node_->get_logger(),
-    "num_channels: %u\nscale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ "
-    "%f\nscale_vel_from_dev_ "
-    "%f\nscale_eff_from_dev_ %f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ "
-    "%f\nhoming_timeout_seconds_ %i\n",
-    num_channels_, scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_,
-    scale_eff_from_dev_, offset_pos_to_dev_, offset_pos_from_dev_, homing_timeout_seconds_);
-
-  // Create per-channel services
-  create_per_channel_services();
+  this->configure_common();
 }
 
 template <class NODETYPE>

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -105,107 +105,109 @@ void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
 
     // Init service
     handle_init_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "init",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_init(request, response, ch);
-      });
+      service_prefix + "init", [this, ch](
+                                 const std_srvs::srv::Trigger::Request::SharedPtr request,
+                                 std_srvs::srv::Trigger::Response::SharedPtr response)
+      { this->handle_init(request, response, ch); });
 
     // Enable service
     handle_enable_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "enable",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_enable(request, response, ch);
-      });
+      service_prefix + "enable", [this, ch](
+                                   const std_srvs::srv::Trigger::Request::SharedPtr request,
+                                   std_srvs::srv::Trigger::Response::SharedPtr response)
+      { this->handle_enable(request, response, ch); });
 
     // Disable service
     handle_disable_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "disable",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_disable(request, response, ch);
-      });
+      service_prefix + "disable", [this, ch](
+                                    const std_srvs::srv::Trigger::Request::SharedPtr request,
+                                    std_srvs::srv::Trigger::Response::SharedPtr response)
+      { this->handle_disable(request, response, ch); });
 
     // Halt service
     handle_halt_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "halt",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_halt(request, response, ch);
-      });
+      service_prefix + "halt", [this, ch](
+                                 const std_srvs::srv::Trigger::Request::SharedPtr request,
+                                 std_srvs::srv::Trigger::Response::SharedPtr response)
+      { this->handle_halt(request, response, ch); });
 
     // Recover service
     handle_recover_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "recover",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_recover(request, response, ch);
-      });
+      service_prefix + "recover", [this, ch](
+                                    const std_srvs::srv::Trigger::Request::SharedPtr request,
+                                    std_srvs::srv::Trigger::Response::SharedPtr response)
+      { this->handle_recover(request, response, ch); });
 
     // Position mode service
-    handle_set_mode_position_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "position_mode",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_set_mode_position(request, response, ch);
-      });
+    handle_set_mode_position_services_[ch] =
+      this->node_->template create_service<std_srvs::srv::Trigger>(
+        service_prefix + "position_mode",
+        [this, ch](
+          const std_srvs::srv::Trigger::Request::SharedPtr request,
+          std_srvs::srv::Trigger::Response::SharedPtr response)
+        { this->handle_set_mode_position(request, response, ch); });
 
     // Velocity mode service
-    handle_set_mode_velocity_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "velocity_mode",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_set_mode_velocity(request, response, ch);
-      });
+    handle_set_mode_velocity_services_[ch] =
+      this->node_->template create_service<std_srvs::srv::Trigger>(
+        service_prefix + "velocity_mode",
+        [this, ch](
+          const std_srvs::srv::Trigger::Request::SharedPtr request,
+          std_srvs::srv::Trigger::Response::SharedPtr response)
+        { this->handle_set_mode_velocity(request, response, ch); });
 
     // Torque mode service
-    handle_set_mode_torque_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "torque_mode",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_set_mode_torque(request, response, ch);
-      });
+    handle_set_mode_torque_services_[ch] =
+      this->node_->template create_service<std_srvs::srv::Trigger>(
+        service_prefix + "torque_mode", [this, ch](
+                                          const std_srvs::srv::Trigger::Request::SharedPtr request,
+                                          std_srvs::srv::Trigger::Response::SharedPtr response)
+        { this->handle_set_mode_torque(request, response, ch); });
 
     // Cyclic velocity mode service
-    handle_set_mode_cyclic_velocity_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "cyclic_velocity_mode",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_set_mode_cyclic_velocity(request, response, ch);
-      });
+    handle_set_mode_cyclic_velocity_services_[ch] =
+      this->node_->template create_service<std_srvs::srv::Trigger>(
+        service_prefix + "cyclic_velocity_mode",
+        [this, ch](
+          const std_srvs::srv::Trigger::Request::SharedPtr request,
+          std_srvs::srv::Trigger::Response::SharedPtr response)
+        { this->handle_set_mode_cyclic_velocity(request, response, ch); });
 
     // Cyclic position mode service
-    handle_set_mode_cyclic_position_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "cyclic_position_mode",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_set_mode_cyclic_position(request, response, ch);
-      });
+    handle_set_mode_cyclic_position_services_[ch] =
+      this->node_->template create_service<std_srvs::srv::Trigger>(
+        service_prefix + "cyclic_position_mode",
+        [this, ch](
+          const std_srvs::srv::Trigger::Request::SharedPtr request,
+          std_srvs::srv::Trigger::Response::SharedPtr response)
+        { this->handle_set_mode_cyclic_position(request, response, ch); });
 
     // Cyclic torque mode service
-    handle_set_mode_cyclic_torque_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "cyclic_torque_mode",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_set_mode_cyclic_torque(request, response, ch);
-      });
+    handle_set_mode_cyclic_torque_services_[ch] =
+      this->node_->template create_service<std_srvs::srv::Trigger>(
+        service_prefix + "cyclic_torque_mode",
+        [this, ch](
+          const std_srvs::srv::Trigger::Request::SharedPtr request,
+          std_srvs::srv::Trigger::Response::SharedPtr response)
+        { this->handle_set_mode_cyclic_torque(request, response, ch); });
 
     // Interpolated position mode service
-    handle_set_mode_interpolated_position_services_[ch] = this->node_->template create_service<std_srvs::srv::Trigger>(
-      service_prefix + "interpolated_position_mode",
-      [this, ch](const std_srvs::srv::Trigger::Request::SharedPtr request,
-                 std_srvs::srv::Trigger::Response::SharedPtr response) {
-        this->handle_set_mode_interpolated_position(request, response, ch);
-      });
+    handle_set_mode_interpolated_position_services_[ch] =
+      this->node_->template create_service<std_srvs::srv::Trigger>(
+        service_prefix + "interpolated_position_mode",
+        [this, ch](
+          const std_srvs::srv::Trigger::Request::SharedPtr request,
+          std_srvs::srv::Trigger::Response::SharedPtr response)
+        { this->handle_set_mode_interpolated_position(request, response, ch); });
 
     // Target service (uses COTargetDouble without channel field, since channel is in service name)
-    handle_set_target_services_[ch] = this->node_->template create_service<canopen_interfaces::srv::COTargetDouble>(
-      service_prefix + "target",
-      [this, ch](const canopen_interfaces::srv::COTargetDouble::Request::SharedPtr request,
-                 canopen_interfaces::srv::COTargetDouble::Response::SharedPtr response) {
-        response->success = this->set_target(request->target, ch);
-      });
+    handle_set_target_services_[ch] =
+      this->node_->template create_service<canopen_interfaces::srv::COTargetDouble>(
+        service_prefix + "target",
+        [this, ch](
+          const canopen_interfaces::srv::COTargetDouble::Request::SharedPtr request,
+          canopen_interfaces::srv::COTargetDouble::Response::SharedPtr response)
+        { response->success = this->set_target(request->target, ch); });
   }
 }
 
@@ -301,7 +303,13 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
 
   // Multi-channel configuration
   num_channels_ = 1;
-  try { num_channels_ = this->config_["num_channels"].as<uint8_t>(); } catch (...) {}
+  try
+  {
+    num_channels_ = this->config_["num_channels"].as<uint8_t>();
+  }
+  catch (...)
+  {
+  }
 
   // Parse channel names
   try
@@ -315,7 +323,9 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
       }
     }
   }
-  catch (...) {}
+  catch (...)
+  {
+  }
 
   // Generate default names if not provided
   if (channel_names_.empty())
@@ -335,28 +345,73 @@ void NodeCanopen402Driver<rclcpp_lifecycle::LifecycleNode>::configure(bool calle
       for (size_t i = 0; i < channels_node.size() && i < num_channels_; ++i)
       {
         auto ch = channels_node[i];
-        try { channel_scale_pos_to_dev_.push_back(ch["scale_pos_to_dev"].as<double>()); }
-        catch (...) { channel_scale_pos_to_dev_.push_back(scale_pos_to_dev_); }
-        try { channel_scale_pos_from_dev_.push_back(ch["scale_pos_from_dev"].as<double>()); }
-        catch (...) { channel_scale_pos_from_dev_.push_back(scale_pos_from_dev_); }
-        try { channel_scale_vel_to_dev_.push_back(ch["scale_vel_to_dev"].as<double>()); }
-        catch (...) { channel_scale_vel_to_dev_.push_back(scale_vel_to_dev_); }
-        try { channel_scale_vel_from_dev_.push_back(ch["scale_vel_from_dev"].as<double>()); }
-        catch (...) { channel_scale_vel_from_dev_.push_back(scale_vel_from_dev_); }
-        try { channel_scale_eff_from_dev_.push_back(ch["scale_eff_from_dev"].as<double>()); }
-        catch (...) { channel_scale_eff_from_dev_.push_back(scale_eff_from_dev_); }
-        try { channel_offset_pos_to_dev_.push_back(ch["offset_pos_to_dev"].as<double>()); }
-        catch (...) { channel_offset_pos_to_dev_.push_back(offset_pos_to_dev_); }
-        try { channel_offset_pos_from_dev_.push_back(ch["offset_pos_from_dev"].as<double>()); }
-        catch (...) { channel_offset_pos_from_dev_.push_back(offset_pos_from_dev_); }
+        try
+        {
+          channel_scale_pos_to_dev_.push_back(ch["scale_pos_to_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_scale_pos_to_dev_.push_back(scale_pos_to_dev_);
+        }
+        try
+        {
+          channel_scale_pos_from_dev_.push_back(ch["scale_pos_from_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_scale_pos_from_dev_.push_back(scale_pos_from_dev_);
+        }
+        try
+        {
+          channel_scale_vel_to_dev_.push_back(ch["scale_vel_to_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_scale_vel_to_dev_.push_back(scale_vel_to_dev_);
+        }
+        try
+        {
+          channel_scale_vel_from_dev_.push_back(ch["scale_vel_from_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_scale_vel_from_dev_.push_back(scale_vel_from_dev_);
+        }
+        try
+        {
+          channel_scale_eff_from_dev_.push_back(ch["scale_eff_from_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_scale_eff_from_dev_.push_back(scale_eff_from_dev_);
+        }
+        try
+        {
+          channel_offset_pos_to_dev_.push_back(ch["offset_pos_to_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_offset_pos_to_dev_.push_back(offset_pos_to_dev_);
+        }
+        try
+        {
+          channel_offset_pos_from_dev_.push_back(ch["offset_pos_from_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_offset_pos_from_dev_.push_back(offset_pos_from_dev_);
+        }
       }
     }
   }
-  catch (...) {}
+  catch (...)
+  {
+  }
 
   RCLCPP_INFO(
     this->node_->get_logger(),
-    "num_channels: %u\nscale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ "
+    "num_channels: %u\nscale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ "
+    "%f\nscale_vel_from_dev_ "
     "%f\nscale_eff_from_dev_ %f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ "
     "%f\nhoming_timeout_seconds_ %i\n",
     num_channels_, scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_,
@@ -458,7 +513,13 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
 
   // Multi-channel configuration
   num_channels_ = 1;
-  try { num_channels_ = this->config_["num_channels"].as<uint8_t>(); } catch (...) {}
+  try
+  {
+    num_channels_ = this->config_["num_channels"].as<uint8_t>();
+  }
+  catch (...)
+  {
+  }
 
   // Parse channel names
   try
@@ -472,7 +533,9 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
       }
     }
   }
-  catch (...) {}
+  catch (...)
+  {
+  }
 
   // Generate default names if not provided
   if (channel_names_.empty())
@@ -492,28 +555,73 @@ void NodeCanopen402Driver<rclcpp::Node>::configure(bool called_from_base)
       for (size_t i = 0; i < channels_node.size() && i < num_channels_; ++i)
       {
         auto ch = channels_node[i];
-        try { channel_scale_pos_to_dev_.push_back(ch["scale_pos_to_dev"].as<double>()); }
-        catch (...) { channel_scale_pos_to_dev_.push_back(scale_pos_to_dev_); }
-        try { channel_scale_pos_from_dev_.push_back(ch["scale_pos_from_dev"].as<double>()); }
-        catch (...) { channel_scale_pos_from_dev_.push_back(scale_pos_from_dev_); }
-        try { channel_scale_vel_to_dev_.push_back(ch["scale_vel_to_dev"].as<double>()); }
-        catch (...) { channel_scale_vel_to_dev_.push_back(scale_vel_to_dev_); }
-        try { channel_scale_vel_from_dev_.push_back(ch["scale_vel_from_dev"].as<double>()); }
-        catch (...) { channel_scale_vel_from_dev_.push_back(scale_vel_from_dev_); }
-        try { channel_scale_eff_from_dev_.push_back(ch["scale_eff_from_dev"].as<double>()); }
-        catch (...) { channel_scale_eff_from_dev_.push_back(scale_eff_from_dev_); }
-        try { channel_offset_pos_to_dev_.push_back(ch["offset_pos_to_dev"].as<double>()); }
-        catch (...) { channel_offset_pos_to_dev_.push_back(offset_pos_to_dev_); }
-        try { channel_offset_pos_from_dev_.push_back(ch["offset_pos_from_dev"].as<double>()); }
-        catch (...) { channel_offset_pos_from_dev_.push_back(offset_pos_from_dev_); }
+        try
+        {
+          channel_scale_pos_to_dev_.push_back(ch["scale_pos_to_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_scale_pos_to_dev_.push_back(scale_pos_to_dev_);
+        }
+        try
+        {
+          channel_scale_pos_from_dev_.push_back(ch["scale_pos_from_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_scale_pos_from_dev_.push_back(scale_pos_from_dev_);
+        }
+        try
+        {
+          channel_scale_vel_to_dev_.push_back(ch["scale_vel_to_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_scale_vel_to_dev_.push_back(scale_vel_to_dev_);
+        }
+        try
+        {
+          channel_scale_vel_from_dev_.push_back(ch["scale_vel_from_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_scale_vel_from_dev_.push_back(scale_vel_from_dev_);
+        }
+        try
+        {
+          channel_scale_eff_from_dev_.push_back(ch["scale_eff_from_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_scale_eff_from_dev_.push_back(scale_eff_from_dev_);
+        }
+        try
+        {
+          channel_offset_pos_to_dev_.push_back(ch["offset_pos_to_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_offset_pos_to_dev_.push_back(offset_pos_to_dev_);
+        }
+        try
+        {
+          channel_offset_pos_from_dev_.push_back(ch["offset_pos_from_dev"].as<double>());
+        }
+        catch (...)
+        {
+          channel_offset_pos_from_dev_.push_back(offset_pos_from_dev_);
+        }
       }
     }
   }
-  catch (...) {}
+  catch (...)
+  {
+  }
 
   RCLCPP_INFO(
     this->node_->get_logger(),
-    "num_channels: %u\nscale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ %f\nscale_vel_from_dev_ "
+    "num_channels: %u\nscale_pos_to_dev_ %f\nscale_pos_from_dev_ %f\nscale_vel_to_dev_ "
+    "%f\nscale_vel_from_dev_ "
     "%f\nscale_eff_from_dev_ %f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ "
     "%f\nhoming_timeout_seconds_ %i\n",
     num_channels_, scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_,
@@ -528,7 +636,7 @@ void NodeCanopen402Driver<NODETYPE>::activate(bool called_from_base)
 {
   NodeCanopenProxyDriver<NODETYPE>::activate(false);
   // Register default modes for all motor instances
-  for (auto& motor : motors_)
+  for (auto & motor : motors_)
   {
     motor->registerDefaultModes();
     motor->set_diagnostic_status_msgs(this->diagnostic_collector_, this->diagnostic_enabled_);
@@ -547,7 +655,7 @@ void NodeCanopen402Driver<NODETYPE>::poll_timer_callback()
 {
   NodeCanopenProxyDriver<NODETYPE>::poll_timer_callback();
   // Handle read/write for all motors
-  for (auto& motor : motors_)
+  for (auto & motor : motors_)
   {
     motor->handleRead();
     motor->handleWrite();
@@ -582,16 +690,21 @@ void NodeCanopen402Driver<NODETYPE>::publish()
       }
     }
 
-    double scale_pos_from_dev = (ch < channel_scale_pos_from_dev_.size()) ?
-                       channel_scale_pos_from_dev_[ch] : scale_pos_from_dev_;
-    double offset_pos_from_dev = (ch < channel_offset_pos_from_dev_.size()) ?
-                        channel_offset_pos_from_dev_[ch] : offset_pos_from_dev_;
-    double scale_vel_from_dev = (ch < channel_scale_vel_from_dev_.size()) ?
-                       channel_scale_vel_from_dev_[ch] : scale_vel_from_dev_;
-    double scale_eff_from_dev = (ch < channel_scale_eff_from_dev_.size()) ?
-                       channel_scale_eff_from_dev_[ch] : scale_eff_from_dev_;
+    double scale_pos_from_dev = (ch < channel_scale_pos_from_dev_.size())
+                                  ? channel_scale_pos_from_dev_[ch]
+                                  : scale_pos_from_dev_;
+    double offset_pos_from_dev = (ch < channel_offset_pos_from_dev_.size())
+                                   ? channel_offset_pos_from_dev_[ch]
+                                   : offset_pos_from_dev_;
+    double scale_vel_from_dev = (ch < channel_scale_vel_from_dev_.size())
+                                  ? channel_scale_vel_from_dev_[ch]
+                                  : scale_vel_from_dev_;
+    double scale_eff_from_dev = (ch < channel_scale_eff_from_dev_.size())
+                                  ? channel_scale_eff_from_dev_[ch]
+                                  : scale_eff_from_dev_;
     js_msg.name.push_back(name);
-    js_msg.position.push_back(motors_[ch]->get_position() * scale_pos_from_dev + offset_pos_from_dev);
+    js_msg.position.push_back(
+      motors_[ch]->get_position() * scale_pos_from_dev + offset_pos_from_dev);
     js_msg.velocity.push_back(motors_[ch]->get_speed() * scale_vel_from_dev);
     js_msg.effort.push_back(motors_[ch]->get_effort() * scale_eff_from_dev);
   }
@@ -606,9 +719,8 @@ void NodeCanopen402Driver<NODETYPE>::add_to_master()
   motors_.clear();
   for (uint8_t ch = 0; ch < num_channels_; ++ch)
   {
-    motors_.push_back(
-      std::make_shared<Motor402>(this->lely_driver_, switching_state_, homing_timeout_seconds_, ch)
-    );
+    motors_.push_back(std::make_shared<Motor402>(
+      this->lely_driver_, switching_state_, homing_timeout_seconds_, ch));
   }
 }
 
@@ -693,7 +805,7 @@ void NodeCanopen402Driver<NODETYPE>::handle_set_target(
   const canopen_interfaces::srv::COTargetDouble::Request::SharedPtr request,
   canopen_interfaces::srv::COTargetDouble::Response::SharedPtr response, const uint8_t channel)
 {
-    response->success = set_target(request->target, channel);
+  response->success = set_target(request->target, channel);
 }
 
 template <class NODETYPE>
@@ -705,7 +817,8 @@ void NodeCanopen402Driver<NODETYPE>::handle_disable(
   {
     response->success = motors_[channel]->handleDisable();
   }
-  else {
+  else
+  {
     response->success = false;
   }
 }
@@ -719,7 +832,8 @@ void NodeCanopen402Driver<NODETYPE>::handle_enable(
   {
     response->success = motors_[channel]->handleEnable();
   }
-  else {
+  else
+  {
     response->success = false;
   }
 }
@@ -731,7 +845,8 @@ bool NodeCanopen402Driver<NODETYPE>::init_motor(uint8_t channel)
   {
     if (channel >= motors_.size())
     {
-      RCLCPP_ERROR(this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+      RCLCPP_ERROR(
+        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
       return false;
     }
     return motors_[channel]->handleInit();
@@ -750,7 +865,8 @@ bool NodeCanopen402Driver<NODETYPE>::recover_motor(uint8_t channel)
   {
     if (channel >= motors_.size())
     {
-      RCLCPP_ERROR(this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+      RCLCPP_ERROR(
+        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
       return false;
     }
     return motors_[channel]->handleRecover();
@@ -768,7 +884,8 @@ bool NodeCanopen402Driver<NODETYPE>::halt_motor(uint8_t channel)
   {
     if (channel >= motors_.size())
     {
-      RCLCPP_ERROR(this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+      RCLCPP_ERROR(
+        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
       return false;
     }
     return motors_[channel]->handleHalt();
@@ -786,7 +903,8 @@ bool NodeCanopen402Driver<NODETYPE>::set_operation_mode(uint16_t mode, uint8_t c
   {
     if (channel >= motors_.size())
     {
-      RCLCPP_ERROR(this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+      RCLCPP_ERROR(
+        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
       return false;
     }
 
@@ -809,19 +927,23 @@ bool NodeCanopen402Driver<NODETYPE>::set_target(double target, uint8_t channel)
   {
     if (channel >= motors_.size())
     {
-      RCLCPP_ERROR(this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
+      RCLCPP_ERROR(
+        this->node_->get_logger(), "Invalid channel %u (max %lu)", channel, motors_.size() - 1);
       return false;
     }
 
     auto mode = motors_[channel]->getMode();
 
     // Get per-channel scales/offsets (or use global as fallback)
-    double scale_pos_to_dev = (channel < channel_scale_pos_to_dev_.size()) ?
-                          channel_scale_pos_to_dev_[channel] : scale_pos_to_dev_;
-    double offset_pos_to_dev = (channel < channel_offset_pos_to_dev_.size()) ?
-                           channel_offset_pos_to_dev_[channel] : offset_pos_to_dev_;
-    double scale_vel_to_dev = (channel < channel_scale_vel_to_dev_.size()) ?
-                          channel_scale_vel_to_dev_[channel] : scale_vel_to_dev_;
+    double scale_pos_to_dev = (channel < channel_scale_pos_to_dev_.size())
+                                ? channel_scale_pos_to_dev_[channel]
+                                : scale_pos_to_dev_;
+    double offset_pos_to_dev = (channel < channel_offset_pos_to_dev_.size())
+                                 ? channel_offset_pos_to_dev_[channel]
+                                 : offset_pos_to_dev_;
+    double scale_vel_to_dev = (channel < channel_scale_vel_to_dev_.size())
+                                ? channel_scale_vel_to_dev_[channel]
+                                : scale_vel_to_dev_;
 
     double scaled_target;
     if (
@@ -870,8 +992,12 @@ void NodeCanopen402Driver<NODETYPE>::diagnostic_callback(
   for (size_t ch = 0; ch < motors_.size(); ++ch)
   {
     std::string ch_prefix = "ch" + std::to_string(ch) + "_";
-    stat.add(ch_prefix + "mode", this->diagnostic_collector_->getValue((ch_prefix + "cia402_mode").c_str()));
-    stat.add(ch_prefix + "state", this->diagnostic_collector_->getValue((ch_prefix + "cia402_state").c_str()));
+    stat.add(
+      ch_prefix + "mode",
+      this->diagnostic_collector_->getValue((ch_prefix + "cia402_mode").c_str()));
+    stat.add(
+      ch_prefix + "state",
+      this->diagnostic_collector_->getValue((ch_prefix + "cia402_state").c_str()));
   }
 }
 

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -86,8 +86,8 @@ void NodeCanopen402Driver<NODETYPE>::create_per_channel_services()
     std::string service_prefix;
     if (num_channels_ == 1)
     {
-      // Single-channel: no prefix, legacy behavior
-      service_prefix = "";
+      // Single-channel: legacy behavior
+      service_prefix = std::string(this->node_->get_name()) + "/";
     }
     else
     {

--- a/canopen_402_driver/include/canopen_402_driver/profiled_position_mode.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/profiled_position_mode.hpp
@@ -27,7 +27,8 @@ namespace ros2_canopen
 {
 class ProfiledPositionMode : public ModeTargetHelper<int32_t>
 {
-  const uint16_t index = 0x607A;
+  const uint16_t base_index = 0x607A;
+  uint16_t channel_offset_;  // Channel offset for multi-axis support (CiA 402-2)
   std::shared_ptr<LelyDriverBridge> driver;
 
   double last_target_;
@@ -46,8 +47,8 @@ public:
     CW_Immediate = Command402::CW_Operation_mode_specific1,
     CW_Blending = Command402::CW_Operation_mode_specific3,
   };
-  ProfiledPositionMode(std::shared_ptr<LelyDriverBridge> driver)
-  : ModeTargetHelper(MotorBase::Profiled_Position)
+  ProfiledPositionMode(std::shared_ptr<LelyDriverBridge> driver, uint16_t channel_offset = 0)
+  : ModeTargetHelper(MotorBase::Profiled_Position), channel_offset_(channel_offset)
   {
     this->driver = driver;
   }
@@ -77,7 +78,8 @@ public:
         }
         else
         {
-          driver->universal_set_value(index, 0x0, target);
+          // Apply channel offset to object dictionary index
+          driver->universal_set_value(base_index + channel_offset_, 0x0, target);
           cw.set(CW_NewPoint);
           last_target_ = target;
         }

--- a/canopen_402_driver/src/default_homing_mode.cpp
+++ b/canopen_402_driver/src/default_homing_mode.cpp
@@ -53,7 +53,8 @@ bool DefaultHomingMode::write(Mode::OpModeAccesser & cw)
 
 bool DefaultHomingMode::executeHoming()
 {
-  int hmode = driver->universal_get_value<int8_t>(index, 0x0);
+  // Apply channel offset to object dictionary index
+  int hmode = driver->universal_get_value<int8_t>(base_index + channel_offset_, 0x0);
   if (hmode == 0)
   {
     return true;

--- a/canopen_402_driver/src/motor.cpp
+++ b/canopen_402_driver/src/motor.cpp
@@ -90,7 +90,8 @@ bool Motor402::switchMode(uint16_t mode)
     }
     if (enable_diagnostics_.load())
     {
-      this->diag_collector_->addf("cia402_mode", "No mode selected: %d (channel %u)", mode, channel_);
+      this->diag_collector_->addf(
+        "cia402_mode", "No mode selected: %d (channel %u)", mode, channel_);
     }
     return true;
   }
@@ -141,9 +142,9 @@ bool Motor402::switchMode(uint16_t mode)
     {
       while (mode_id_ != mode && std::chrono::steady_clock::now() < abstime)
       {
-        lock.unlock();                                                    // unlock inside loop
+        lock.unlock();  // unlock inside loop
         driver->universal_get_value<int8_t>(get_channel_index(op_mode_display_index), 0x0);  // poll
-        std::this_thread::sleep_for(std::chrono::milliseconds(20));       // wait some time
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));  // wait some time
         lock.lock();
       }
     }
@@ -154,7 +155,8 @@ bool Motor402::switchMode(uint16_t mode)
       okay = true;
       if (enable_diagnostics_.load())
       {
-        this->diag_collector_->addf("cia402_mode", "Mode switched to: %d (channel %u)", mode, channel_);
+        this->diag_collector_->addf(
+          "cia402_mode", "Mode switched to: %d (channel %u)", mode, channel_);
       }
     }
     else
@@ -163,7 +165,8 @@ bool Motor402::switchMode(uint16_t mode)
       driver->universal_set_value<int8_t>(get_channel_index(op_mode_index), 0x0, mode_id_);
       if (enable_diagnostics_.load())
       {
-        this->diag_collector_->addf("cia402_mode", "Mode switch timed out: %d (channel %u)", mode, channel_);
+        this->diag_collector_->addf(
+          "cia402_mode", "Mode switch timed out: %d (channel %u)", mode, channel_);
       }
     }
   }
@@ -210,8 +213,9 @@ bool Motor402::switchState(const State402::InternalState & target)
 
 bool Motor402::readState()
 {
-  uint16_t old_sw, sw = driver->universal_get_value<uint16_t>(
-                     get_channel_index(status_word_entry_index), 0x0);  // TODO: added error handling
+  uint16_t old_sw,
+    sw = driver->universal_get_value<uint16_t>(
+      get_channel_index(status_word_entry_index), 0x0);  // TODO: added error handling
   old_sw = status_word_.exchange(sw);
 
   state_handler_.read(sw);
@@ -278,13 +282,15 @@ void Motor402::handleWrite()
   {
     RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Fault reset (channel %u)", channel_);
     this->driver->universal_set_value<uint16_t>(
-      get_channel_index(control_word_entry_index), 0x0, control_word_ & ~(1 << Command402::CW_Fault_Reset));
+      get_channel_index(control_word_entry_index), 0x0,
+      control_word_ & ~(1 << Command402::CW_Fault_Reset));
   }
   else
   {
     // RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Control Word %s",
     // std::bitset<16>{control_word_}.to_string());
-    this->driver->universal_set_value<uint16_t>(get_channel_index(control_word_entry_index), 0x0, control_word_);
+    this->driver->universal_set_value<uint16_t>(
+      get_channel_index(control_word_entry_index), 0x0, control_word_);
   }
 }
 void Motor402::handleDiag()

--- a/canopen_402_driver/src/motor.cpp
+++ b/canopen_402_driver/src/motor.cpp
@@ -48,7 +48,7 @@ uint16_t Motor402::getMode()
 bool Motor402::isModeSupportedByDevice(uint16_t mode)
 {
   uint32_t supported_modes =
-    driver->universal_get_value<uint32_t>(supported_drive_modes_index, 0x0);
+    driver->universal_get_value<uint32_t>(get_channel_index(supported_drive_modes_index), 0x0);
   bool supported = supported_modes & (1 << (mode - 1));
   bool below_max = mode <= 32;
   bool above_min = mode > 0;
@@ -82,15 +82,15 @@ bool Motor402::switchMode(uint16_t mode)
     std::scoped_lock lock(mode_mutex_);
     selected_mode_.reset();
     try
-    {  // try to set mode
-      driver->universal_set_value<int8_t>(op_mode_index, 0x0, mode);
+    {  // try to set mode (use channel-specific index)
+      driver->universal_set_value<int8_t>(get_channel_index(op_mode_index), 0x0, mode);
     }
     catch (...)
     {
     }
     if (enable_diagnostics_.load())
     {
-      this->diag_collector_->addf("cia402_mode", "No mode selected: %d", mode);
+      this->diag_collector_->addf("cia402_mode", "No mode selected: %d (channel %u)", mode, channel_);
     }
     return true;
   }
@@ -122,7 +122,7 @@ bool Motor402::switchMode(uint16_t mode)
 
   if (!switchState(switching_state_)) return false;
 
-  driver->universal_set_value<int8_t>(op_mode_index, 0x0, mode);
+  driver->universal_set_value<int8_t>(get_channel_index(op_mode_index), 0x0, mode);
 
   bool okay = false;
 
@@ -142,7 +142,7 @@ bool Motor402::switchMode(uint16_t mode)
       while (mode_id_ != mode && std::chrono::steady_clock::now() < abstime)
       {
         lock.unlock();                                                    // unlock inside loop
-        driver->universal_get_value<int8_t>(op_mode_display_index, 0x0);  // poll
+        driver->universal_get_value<int8_t>(get_channel_index(op_mode_display_index), 0x0);  // poll
         std::this_thread::sleep_for(std::chrono::milliseconds(20));       // wait some time
         lock.lock();
       }
@@ -154,16 +154,16 @@ bool Motor402::switchMode(uint16_t mode)
       okay = true;
       if (enable_diagnostics_.load())
       {
-        this->diag_collector_->addf("cia402_mode", "Mode switched to: %d", mode);
+        this->diag_collector_->addf("cia402_mode", "Mode switched to: %d (channel %u)", mode, channel_);
       }
     }
     else
     {
       RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Mode switch timed out.");
-      driver->universal_set_value<int8_t>(op_mode_index, 0x0, mode_id_);
+      driver->universal_set_value<int8_t>(get_channel_index(op_mode_index), 0x0, mode_id_);
       if (enable_diagnostics_.load())
       {
-        this->diag_collector_->addf("cia402_mode", "Mode switch timed out: %d", mode);
+        this->diag_collector_->addf("cia402_mode", "Mode switch timed out: %d (channel %u)", mode, channel_);
       }
     }
   }
@@ -211,14 +211,14 @@ bool Motor402::switchState(const State402::InternalState & target)
 bool Motor402::readState()
 {
   uint16_t old_sw, sw = driver->universal_get_value<uint16_t>(
-                     status_word_entry_index, 0x0);  // TODO: added error handling
+                     get_channel_index(status_word_entry_index), 0x0);  // TODO: added error handling
   old_sw = status_word_.exchange(sw);
 
   state_handler_.read(sw);
 
   std::unique_lock lock(mode_mutex_);
   uint16_t new_mode;
-  new_mode = driver->universal_get_value<int8_t>(op_mode_display_index, 0x0);
+  new_mode = driver->universal_get_value<int8_t>(get_channel_index(op_mode_display_index), 0x0);
   // RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Mode %hhi",new_mode);
 
   if (selected_mode_ && selected_mode_->mode_id_ == new_mode)
@@ -276,15 +276,15 @@ void Motor402::handleWrite()
   }
   if (start_fault_reset_.exchange(false))
   {
-    RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Fault reset");
+    RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Fault reset (channel %u)", channel_);
     this->driver->universal_set_value<uint16_t>(
-      control_word_entry_index, 0x0, control_word_ & ~(1 << Command402::CW_Fault_Reset));
+      get_channel_index(control_word_entry_index), 0x0, control_word_ & ~(1 << Command402::CW_Fault_Reset));
   }
   else
   {
     // RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Control Word %s",
     // std::bitset<16>{control_word_}.to_string());
-    this->driver->universal_set_value<uint16_t>(control_word_entry_index, 0x0, control_word_);
+    this->driver->universal_set_value<uint16_t>(get_channel_index(control_word_entry_index), 0x0, control_word_);
   }
 }
 void Motor402::handleDiag()

--- a/canopen_ros2_control/include/canopen_ros2_control/cia402_data.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/cia402_data.hpp
@@ -65,13 +65,13 @@ struct Cia402Data
     }
 
     node_id = config["node_id"].as<uint16_t>();
-    
+
     // Get channel parameter (defaults to 0 for backward compatibility)
     if (config["channel"])
     {
       channel = config["channel"].as<uint8_t>();
       RCLCPP_INFO(
-        rclcpp::get_logger(joint_name), "Node id for '%s' is '%u', channel is '%u'", 
+        rclcpp::get_logger(joint_name), "Node id for '%s' is '%u', channel is '%u'",
         joint.name.c_str(), node_id, channel);
     }
     else

--- a/canopen_ros2_control/include/canopen_ros2_control/cia402_data.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/cia402_data.hpp
@@ -33,6 +33,7 @@ namespace canopen_ros2_control
 struct Cia402Data
 {
   uint8_t node_id;
+  uint8_t channel = 0;  // Channel for multi-axis support (0 for single-axis, 1+ for multi-axis)
   std::string joint_name;
   std::shared_ptr<ros2_canopen::Cia402Driver> driver;
   std::map<std::string, ros2_canopen::MotorBase::OperationMode> command_interface_to_operation_mode;
@@ -64,8 +65,20 @@ struct Cia402Data
     }
 
     node_id = config["node_id"].as<uint16_t>();
-    RCLCPP_ERROR(
-      rclcpp::get_logger(joint_name), "Node id for '%s' is '%u'", joint.name.c_str(), node_id);
+    
+    // Get channel parameter (defaults to 0 for backward compatibility)
+    if (config["channel"])
+    {
+      channel = config["channel"].as<uint8_t>();
+      RCLCPP_INFO(
+        rclcpp::get_logger(joint_name), "Node id for '%s' is '%u', channel is '%u'", 
+        joint.name.c_str(), node_id, channel);
+    }
+    else
+    {
+      RCLCPP_ERROR(
+        rclcpp::get_logger(joint_name), "Node id for '%s' is '%u'", joint.name.c_str(), node_id);
+    }
 
     if (config["position_mode"])
     {

--- a/canopen_ros2_control/include/canopen_ros2_control/cia402_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/cia402_system.hpp
@@ -118,21 +118,25 @@ protected:
   // Map from (node_id, channel) to motor data for multi-channel support
   // channel 0 is used for single-channel devices for backward compatibility
   std::map<std::pair<uint, uint>, MotorNodeData> motor_data_;
-  
+
   // Helper to get motor data key
-  std::pair<uint, uint> getMotorKey(uint node_id, uint channel = 0) const 
-  { 
-    return std::make_pair(node_id, channel); 
+  std::pair<uint, uint> getMotorKey(uint node_id, uint channel = 0) const
+  {
+    return std::make_pair(node_id, channel);
   }
 
 private:
-  void switchModes(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
+  void switchModes(
+    uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
 
-  void handleInit(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
+  void handleInit(
+    uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
 
-  void handleRecover(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
+  void handleRecover(
+    uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
 
-  void handleHalt(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
+  void handleHalt(
+    uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
 
   void initDeviceContainer();
 };

--- a/canopen_ros2_control/include/canopen_ros2_control/cia402_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/cia402_system.hpp
@@ -115,16 +115,24 @@ public:
 
 protected:
   // can stuff
-  std::map<uint, MotorNodeData> motor_data_;
+  // Map from (node_id, channel) to motor data for multi-channel support
+  // channel 0 is used for single-channel devices for backward compatibility
+  std::map<std::pair<uint, uint>, MotorNodeData> motor_data_;
+  
+  // Helper to get motor data key
+  std::pair<uint, uint> getMotorKey(uint node_id, uint channel = 0) const 
+  { 
+    return std::make_pair(node_id, channel); 
+  }
 
 private:
-  void switchModes(uint id, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
+  void switchModes(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
 
-  void handleInit(uint id, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
+  void handleInit(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
 
-  void handleRecover(uint id, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
+  void handleRecover(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
 
-  void handleHalt(uint id, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
+  void handleHalt(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver);
 
   void initDeviceContainer();
 };

--- a/canopen_ros2_control/src/canopen_system.cpp
+++ b/canopen_ros2_control/src/canopen_system.cpp
@@ -293,7 +293,7 @@ hardware_interface::return_type CanopenSystem::read(
     }
   }
 
-  return hardware_interface::return_type::ERROR;
+  return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type CanopenSystem::write(

--- a/canopen_ros2_control/src/cia402_system.cpp
+++ b/canopen_ros2_control/src/cia402_system.cpp
@@ -129,17 +129,27 @@ std::vector<hardware_interface::StateInterface> Cia402System::export_state_inter
     }
     const uint8_t node_id = static_cast<uint8_t>(std::stoi(info_.joints[i].parameters["node_id"]));
 
+    // Get channel parameter (defaults to 0 for backward compatibility)
+    uint8_t channel = 0;
+    if (info_.joints[i].parameters.find("channel") != info_.joints[i].parameters.end())
+    {
+      channel = static_cast<uint8_t>(std::stoi(info_.joints[i].parameters["channel"]));
+    }
+
+    auto motor_key = getMotorKey(node_id, channel);
+
     // actual position
     state_interfaces.emplace_back(hardware_interface::StateInterface(
       info_.joints[i].name, hardware_interface::HW_IF_POSITION,
-      &motor_data_[node_id].actual_position));
+      &motor_data_[motor_key].actual_position));
     // actual speed
     state_interfaces.emplace_back(hardware_interface::StateInterface(
       info_.joints[i].name, hardware_interface::HW_IF_VELOCITY,
-      &motor_data_[node_id].actual_speed));
+      &motor_data_[motor_key].actual_speed));
     // actual effort
     state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &motor_data_[node_id].actual_effort));
+      info_.joints[i].name, hardware_interface::HW_IF_EFFORT,
+      &motor_data_[motor_key].actual_effort));
   }
 
   return state_interfaces;
@@ -162,67 +172,76 @@ std::vector<hardware_interface::CommandInterface> Cia402System::export_command_i
 
     const uint8_t node_id = static_cast<uint8_t>(std::stoi(info_.joints[i].parameters["node_id"]));
 
+    // Get channel parameter (defaults to 0 for backward compatibility)
+    uint8_t channel = 0;
+    if (info_.joints[i].parameters.find("channel") != info_.joints[i].parameters.end())
+    {
+      channel = static_cast<uint8_t>(std::stoi(info_.joints[i].parameters["channel"]));
+    }
+
+    auto motor_key = getMotorKey(node_id, channel);
+
     // target
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, hardware_interface::HW_IF_POSITION,
-      &motor_data_[node_id].target.position_value));
+      &motor_data_[motor_key].target.position_value));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, hardware_interface::HW_IF_VELOCITY,
-      &motor_data_[node_id].target.velocity_value));
+      &motor_data_[motor_key].target.velocity_value));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, hardware_interface::HW_IF_EFFORT,
-      &motor_data_[node_id].target.torque_value));
+      &motor_data_[motor_key].target.torque_value));
     // init
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, "init_cmd", &motor_data_[node_id].init.ons_cmd));
+      info_.joints[i].name, "init_cmd", &motor_data_[motor_key].init.ons_cmd));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, "init_fbk", &motor_data_[node_id].init.resp));
+      info_.joints[i].name, "init_fbk", &motor_data_[motor_key].init.resp));
 
     // halt
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, "halt_cmd", &motor_data_[node_id].halt.ons_cmd));
+      info_.joints[i].name, "halt_cmd", &motor_data_[motor_key].halt.ons_cmd));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, "halt_fbk", &motor_data_[node_id].halt.resp));
+      info_.joints[i].name, "halt_fbk", &motor_data_[motor_key].halt.resp));
 
     // recover
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, "recover_cmd", &motor_data_[node_id].recover.ons_cmd));
+      info_.joints[i].name, "recover_cmd", &motor_data_[motor_key].recover.ons_cmd));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, "recover_fbk", &motor_data_[node_id].recover.resp));
+      info_.joints[i].name, "recover_fbk", &motor_data_[motor_key].recover.resp));
 
     // set position mode
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, "position_mode_cmd", &motor_data_[node_id].position_mode.ons_cmd));
+      info_.joints[i].name, "position_mode_cmd", &motor_data_[motor_key].position_mode.ons_cmd));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, "position_mode_fbk", &motor_data_[node_id].position_mode.resp));
+      info_.joints[i].name, "position_mode_fbk", &motor_data_[motor_key].position_mode.resp));
 
     // set velocity mode
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, "velocity_mode_cmd", &motor_data_[node_id].velocity_mode.ons_cmd));
+      info_.joints[i].name, "velocity_mode_cmd", &motor_data_[motor_key].velocity_mode.ons_cmd));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[i].name, "velocity_mode_fbk", &motor_data_[node_id].velocity_mode.resp));
+      info_.joints[i].name, "velocity_mode_fbk", &motor_data_[motor_key].velocity_mode.resp));
 
     // set cyclic velocity mode
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, "cyclic_velocity_mode_cmd",
-      &motor_data_[node_id].cyclic_velocity_mode.ons_cmd));
+      &motor_data_[motor_key].cyclic_velocity_mode.ons_cmd));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, "cyclic_velocity_mode_fbk",
-      &motor_data_[node_id].cyclic_velocity_mode.resp));
+      &motor_data_[motor_key].cyclic_velocity_mode.resp));
     // set cyclic position mode
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, "cyclic_position_mode_cmd",
-      &motor_data_[node_id].cyclic_position_mode.ons_cmd));
+      &motor_data_[motor_key].cyclic_position_mode.ons_cmd));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, "cyclic_position_mode_fbk",
-      &motor_data_[node_id].cyclic_position_mode.resp));
+      &motor_data_[motor_key].cyclic_position_mode.resp));
     // set interpolated position mode
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, "interpolated_position_mode_cmd",
-      &motor_data_[node_id].interpolated_position_mode.ons_cmd));
+      &motor_data_[motor_key].interpolated_position_mode.ons_cmd));
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       info_.joints[i].name, "interpolated_position_mode_fbk",
-      &motor_data_[node_id].interpolated_position_mode.resp));
+      &motor_data_[motor_key].interpolated_position_mode.resp));
   }
 
   return command_interfaces;
@@ -249,16 +268,20 @@ hardware_interface::return_type Cia402System::read(
 
   auto drivers = device_container_->get_registered_drivers();
 
-  for (auto it = canopen_data_.begin(); it != canopen_data_.end(); ++it)
+  // Iterate through all motor data entries which now include channel info
+  for (auto it = motor_data_.begin(); it != motor_data_.end(); ++it)
   {
+    const auto & node_id = it->first.first;
+    const auto & channel = it->first.second;
+
     auto motion_controller_driver =
-      std::static_pointer_cast<ros2_canopen::Cia402Driver>(drivers[it->first]);
+      std::static_pointer_cast<ros2_canopen::Cia402Driver>(drivers[node_id]);
     // get position
-    motor_data_[it->first].actual_position = motion_controller_driver->get_position();
+    motor_data_[it->first].actual_position = motion_controller_driver->get_position(channel);
     // get speed
-    motor_data_[it->first].actual_speed = motion_controller_driver->get_speed();
+    motor_data_[it->first].actual_speed = motion_controller_driver->get_speed(channel);
     // get effort
-    motor_data_[it->first].actual_effort = motion_controller_driver->get_effort();
+    motor_data_[it->first].actual_effort = motion_controller_driver->get_effort(channel);
   }
 
   return ret_val;
@@ -269,9 +292,9 @@ hardware_interface::return_type Cia402System::write(
 {
   auto drivers = device_container_->get_registered_drivers();
 
+  // Process NMT commands per node (not per channel)
   for (auto it = canopen_data_.begin(); it != canopen_data_.end(); ++it)
   {
-    // TODO(livanov93): check casting
     auto motion_controller_driver =
       std::static_pointer_cast<ros2_canopen::Cia402Driver>(drivers[it->first]);
     // do same as in proxy system first - handle nmt, tpdo, rpdo
@@ -293,20 +316,30 @@ hardware_interface::return_type Cia402System::write(
       it->second.tpdo_data.prepare_data();
       motion_controller_driver->tpdo_transmit(it->second.tpdo_data.original_data);
     }
+  }
+
+  // Process motor commands per channel
+  for (auto it = motor_data_.begin(); it != motor_data_.end(); ++it)
+  {
+    const auto & node_id = it->first.first;
+    const auto & channel = it->first.second;
+
+    auto motion_controller_driver =
+      std::static_pointer_cast<ros2_canopen::Cia402Driver>(drivers[node_id]);
 
     // initialisation
-    handleInit(it->first, motion_controller_driver);
+    handleInit(node_id, channel, motion_controller_driver);
 
     // halt
-    handleHalt(it->first, motion_controller_driver);
+    handleHalt(node_id, channel, motion_controller_driver);
 
     // recover
-    handleRecover(it->first, motion_controller_driver);
+    handleRecover(node_id, channel, motion_controller_driver);
 
     // mode switching
-    switchModes(it->first, motion_controller_driver);
+    switchModes(node_id, channel, motion_controller_driver);
 
-    const uint16_t & mode = motion_controller_driver->get_mode();
+    const uint16_t & mode = motion_controller_driver->get_mode(channel);
 
     switch (mode)
     {
@@ -315,14 +348,14 @@ hardware_interface::return_type Cia402System::write(
       case MotorBase::Profiled_Position:
       case MotorBase::Cyclic_Synchronous_Position:
       case MotorBase::Interpolated_Position:
-        motion_controller_driver->set_target(motor_data_[it->first].target.position_value);
+        motion_controller_driver->set_target(motor_data_[it->first].target.position_value, channel);
         break;
       case MotorBase::Profiled_Velocity:
       case MotorBase::Cyclic_Synchronous_Velocity:
-        motion_controller_driver->set_target(motor_data_[it->first].target.velocity_value);
+        motion_controller_driver->set_target(motor_data_[it->first].target.velocity_value, channel);
         break;
       case MotorBase::Profiled_Torque:
-        motion_controller_driver->set_target(motor_data_[it->first].target.torque_value);
+        motion_controller_driver->set_target(motor_data_[it->first].target.torque_value, channel);
         break;
       default:
         RCLCPP_INFO(kLogger, "Mode %u not supported", mode);
@@ -332,67 +365,72 @@ hardware_interface::return_type Cia402System::write(
   return hardware_interface::return_type::OK;
 }
 
-void Cia402System::switchModes(uint id, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
+void Cia402System::switchModes(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
 {
-  if (motor_data_[id].position_mode.is_commanded())
+  auto motor_key = getMotorKey(id, channel);
+
+  if (motor_data_[motor_key].position_mode.is_commanded())
   {
-    motor_data_[id].position_mode.set_response(
-      driver->set_operation_mode(MotorBase::Profiled_Position));
+    motor_data_[motor_key].position_mode.set_response(
+      driver->set_operation_mode(MotorBase::Profiled_Position, channel));
   }
 
-  if (motor_data_[id].cyclic_position_mode.is_commanded())
+  if (motor_data_[motor_key].cyclic_position_mode.is_commanded())
   {
-    motor_data_[id].cyclic_position_mode.set_response(
-      driver->set_operation_mode(MotorBase::Cyclic_Synchronous_Position));
+    motor_data_[motor_key].cyclic_position_mode.set_response(
+      driver->set_operation_mode(MotorBase::Cyclic_Synchronous_Position, channel));
   }
 
-  if (motor_data_[id].velocity_mode.is_commanded())
+  if (motor_data_[motor_key].velocity_mode.is_commanded())
   {
-    motor_data_[id].velocity_mode.set_response(
-      driver->set_operation_mode(MotorBase::Profiled_Velocity));
+    motor_data_[motor_key].velocity_mode.set_response(
+      driver->set_operation_mode(MotorBase::Profiled_Velocity, channel));
   }
 
-  if (motor_data_[id].cyclic_velocity_mode.is_commanded())
+  if (motor_data_[motor_key].cyclic_velocity_mode.is_commanded())
   {
-    motor_data_[id].cyclic_velocity_mode.set_response(
-      driver->set_operation_mode(MotorBase::Cyclic_Synchronous_Velocity));
+    motor_data_[motor_key].cyclic_velocity_mode.set_response(
+      driver->set_operation_mode(MotorBase::Cyclic_Synchronous_Velocity, channel));
   }
 
-  if (motor_data_[id].torque_mode.is_commanded())
+  if (motor_data_[motor_key].torque_mode.is_commanded())
   {
-    motor_data_[id].torque_mode.set_response(
-      driver->set_operation_mode(MotorBase::Profiled_Torque));
+    motor_data_[motor_key].torque_mode.set_response(
+      driver->set_operation_mode(MotorBase::Profiled_Torque, channel));
   }
 
-  if (motor_data_[id].interpolated_position_mode.is_commanded())
+  if (motor_data_[motor_key].interpolated_position_mode.is_commanded())
   {
-    motor_data_[id].interpolated_position_mode.set_response(
-      driver->set_operation_mode(MotorBase::Interpolated_Position));
+    motor_data_[motor_key].interpolated_position_mode.set_response(
+      driver->set_operation_mode(MotorBase::Interpolated_Position, channel));
   }
 }
 
-void Cia402System::handleInit(uint id, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
+void Cia402System::handleInit(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
 {
-  if (motor_data_[id].init.is_commanded())
+  auto motor_key = getMotorKey(id, channel);
+  if (motor_data_[motor_key].init.is_commanded())
   {
-    motor_data_[id].init.set_response(driver->init_motor());
+    motor_data_[motor_key].init.set_response(driver->init_motor(channel));
   }
 }
 
 void Cia402System::handleRecover(
-  uint id, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
+  uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
 {
-  if (motor_data_[id].recover.is_commanded())
+  auto motor_key = getMotorKey(id, channel);
+  if (motor_data_[motor_key].recover.is_commanded())
   {
-    motor_data_[id].recover.set_response(driver->recover_motor());
+    motor_data_[motor_key].recover.set_response(driver->recover_motor(channel));
   }
 }
 
-void Cia402System::handleHalt(uint id, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
+void Cia402System::handleHalt(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
 {
-  if (motor_data_[id].halt.is_commanded())
+  auto motor_key = getMotorKey(id, channel);
+  if (motor_data_[motor_key].halt.is_commanded())
   {
-    motor_data_[id].halt.set_response(driver->halt_motor());
+    motor_data_[motor_key].halt.set_response(driver->halt_motor(channel));
   }
 }
 

--- a/canopen_ros2_control/src/cia402_system.cpp
+++ b/canopen_ros2_control/src/cia402_system.cpp
@@ -365,7 +365,8 @@ hardware_interface::return_type Cia402System::write(
   return hardware_interface::return_type::OK;
 }
 
-void Cia402System::switchModes(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
+void Cia402System::switchModes(
+  uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
 {
   auto motor_key = getMotorKey(id, channel);
 
@@ -406,7 +407,8 @@ void Cia402System::switchModes(uint id, uint channel, const std::shared_ptr<ros2
   }
 }
 
-void Cia402System::handleInit(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
+void Cia402System::handleInit(
+  uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
 {
   auto motor_key = getMotorKey(id, channel);
   if (motor_data_[motor_key].init.is_commanded())
@@ -425,7 +427,8 @@ void Cia402System::handleRecover(
   }
 }
 
-void Cia402System::handleHalt(uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
+void Cia402System::handleHalt(
+  uint id, uint channel, const std::shared_ptr<ros2_canopen::Cia402Driver> & driver)
 {
   auto motor_key = getMotorKey(id, channel);
   if (motor_data_[motor_key].halt.is_commanded())

--- a/canopen_tests/config/cia402_multichannel_system/README.md
+++ b/canopen_tests/config/cia402_multichannel_system/README.md
@@ -52,7 +52,7 @@ When using ros2_control, the hardware interface must specify the channel for eac
     <param name="can_interface_name">vcan0</param>
     <param name="master_bin"></param>
   </hardware>
-  
+
   <!-- First axis (channel 0) -->
   <joint name="node_2_channel_0">
     <command_interface name="position"/>
@@ -62,7 +62,7 @@ When using ros2_control, the hardware interface must specify the channel for eac
     <param name="node_id">2</param>
     <param name="channel">0</param>  <!-- Channel specification -->
   </joint>
-  
+
   <!-- Second axis (channel 1) -->
   <joint name="node_2_channel_1">
     <command_interface name="position"/>

--- a/canopen_tests/config/cia402_multichannel_system/README.md
+++ b/canopen_tests/config/cia402_multichannel_system/README.md
@@ -1,0 +1,125 @@
+# Multi-Channel CiA 402 System Configuration
+
+This configuration demonstrates the multi-channel/multi-axes feature as described in CiA 302-7 and CiA 402-2 specifications.
+
+## Overview
+
+Multi-channel devices allow controlling multiple independent axes over a single CANopen Node-ID. This is useful for:
+- Multi-axis motor controllers (e.g., dual-axis servo drives)
+- Coordinated motion control systems
+- Reducing network complexity by consolidating multiple axes into one node
+
+## CiA 402-2 Specification
+
+According to CiA 402-2, multi-axis devices use offset object dictionary indices:
+
+- **Channel 0** (standard): Indices 0x6000-0x67FF
+- **Channel 1**: Indices 0x6800-0x6FFF (offset +0x800)
+- **Channel 2**: Indices 0x7000-0x77FF (offset +0x1000)
+- **Channel N**: Indices 0x6000 + (N * 0x800)
+
+### Common Object Examples
+
+| Object | Channel 0 | Channel 1 | Channel 2 |
+|--------|-----------|-----------|-----------|
+| Controlword | 0x6040 | 0x6840 | 0x7040 |
+| Statusword | 0x6041 | 0x6841 | 0x7041 |
+| Modes of operation | 0x6060 | 0x6860 | 0x7060 |
+| Position actual value | 0x6064 | 0x6864 | 0x7064 |
+| Velocity actual value | 0x606C | 0x686C | 0x706C |
+| Target position | 0x607A | 0x687A | 0x707A |
+| Target velocity | 0x60FF | 0x68FF | 0x70FF |
+
+## Configuration Structure
+
+### Bus Configuration (bus.yml)
+
+The bus configuration defines:
+1. PDO mappings for each channel with appropriate index offsets
+2. SDO initialization values for each channel
+3. A single node_id that hosts multiple channels
+
+### Hardware Description (URDF)
+
+When using ros2_control, the hardware interface must specify the channel for each joint:
+
+```xml
+<ros2_control name="cia402_multichannel_system" type="system">
+  <hardware>
+    <plugin>canopen_ros2_control/Cia402System</plugin>
+    <param name="bus_config">$(find canopen_tests)/config/cia402_multichannel_system/bus.yml</param>
+    <param name="master_config">$(find canopen_tests)/config/master.dcf</param>
+    <param name="can_interface_name">vcan0</param>
+    <param name="master_bin"></param>
+  </hardware>
+  
+  <!-- First axis (channel 0) -->
+  <joint name="node_2_channel_0">
+    <command_interface name="position"/>
+    <command_interface name="velocity"/>
+    <state_interface name="position"/>
+    <state_interface name="velocity"/>
+    <param name="node_id">2</param>
+    <param name="channel">0</param>  <!-- Channel specification -->
+  </joint>
+  
+  <!-- Second axis (channel 1) -->
+  <joint name="node_2_channel_1">
+    <command_interface name="position"/>
+    <command_interface name="velocity"/>
+    <state_interface name="position"/>
+    <state_interface name="velocity"/>
+    <param name="node_id">2</param>
+    <param name="channel">1</param>  <!-- Channel specification -->
+  </joint>
+</ros2_control>
+```
+
+### Key Parameters
+
+- **node_id**: The CANopen node ID of the device
+- **channel**: The channel/axis number within that device (0, 1, 2, ...)
+  - Defaults to 0 if not specified (backward compatible)
+  - Used to calculate the object dictionary index offset
+
+## Backward Compatibility
+
+The multi-channel feature is fully backward compatible:
+
+- If the `channel` parameter is not specified, it defaults to 0
+- Channel 0 uses standard object indices (no offset)
+- Existing single-axis configurations work without modification
+
+## Usage Example
+
+1. Configure the bus with appropriate PDO mappings for all channels
+2. In your URDF, specify joints with their `node_id` and `channel`
+3. Use standard ros2_control interfaces to control each axis independently
+4. Each channel operates as an independent joint in the system
+
+## Hardware Requirements
+
+Your CANopen device must:
+- Support CiA 402-2 multi-axis specification
+- Implement object dictionary entries at the correct offset indices
+- Have appropriate EDS/DCF file defining all channel objects
+
+## Testing
+
+To test this configuration with simulated devices:
+
+```bash
+# Set up virtual CAN interface
+sudo modprobe vcan
+sudo ip link add dev vcan0 type vcan
+sudo ip link set vcan0 txqueuelen 1000
+sudo ip link set up vcan0
+
+# Launch the multi-channel system
+ros2 launch canopen_tests cia402_multichannel_system_setup.launch.py
+```
+
+## References
+
+- CiA 302-7: Framework for programmable CANopen devices - Part 7: Multi-axis positioning controller
+- CiA 402-2: CANopen device profile for drives and motion control - Part 2: Multiple axis communication parameter

--- a/canopen_tests/config/cia402_multichannel_system/bus.yml
+++ b/canopen_tests/config/cia402_multichannel_system/bus.yml
@@ -1,0 +1,170 @@
+options:
+  dcf_path: "@BUS_CONFIG_PATH@"
+
+master:
+  node_id: 1
+  driver: "ros2_canopen::MasterDriver"
+  package: "canopen_master_driver"
+  sync_period: 10000
+
+# Multi-channel device configuration for CiA 402-2
+# This example shows a device at node_id 2 with two channels (axes)
+nodes:
+  # Single device with two channels
+  cia402_multichannel_device:
+    node_id: 2
+    driver: "ros2_canopen::Cia402Driver"
+    package: "canopen_402_driver"
+    dcf: "cia402_slave_multichannel.eds"
+    period: 10
+    revision_number: 0
+
+    # Multi-channel configuration
+    num_channels: 2  # Number of axes/channels on this device
+
+    # Optional: Custom names for each channel (used in joint_states topic)
+    # If not provided, defaults to <node_name>/0, <node_name>/1, etc.
+    channel_names:
+      - "joint_0"
+      - "joint_1"
+
+    # Global scale factors and offsets (used as defaults for all channels)
+    scale_pos_to_dev: 1000.0       # Convert position from SI units to device units
+    scale_pos_from_dev: 0.001      # Convert position from device units to SI units
+    scale_vel_to_dev: 1000.0       # Convert velocity from SI units to device units
+    scale_vel_from_dev: 0.001      # Convert velocity from device units to SI units
+    offset_pos_to_dev: 0.0         # Offset when converting position to device
+    offset_pos_from_dev: 0.0       # Offset when converting position from device
+
+    # Optional: Per-channel scale factors and offsets (override global settings)
+    # If a channel is not listed, it will use the global values above
+    channels:
+      - # Channel 0 configuration
+        scale_pos_to_dev: 1000.0
+        scale_pos_from_dev: 0.001
+        scale_vel_to_dev: 1000.0
+        scale_vel_from_dev: 0.001
+        offset_pos_to_dev: 0.0
+        offset_pos_from_dev: 0.0
+      - # Channel 1 configuration (different scale for this axis)
+        scale_pos_to_dev: 2000.0
+        scale_pos_from_dev: 0.0005
+        scale_vel_to_dev: 2000.0
+        scale_vel_from_dev: 0.0005
+        offset_pos_to_dev: 10.0
+        offset_pos_from_dev: 5.0
+
+    # Other CIA 402 settings
+    switching_state: 8              # Target state for mode switching (8 = Operation Enable)
+    homing_timeout_seconds: 10      # Timeout for homing operation
+
+
+    # Usage notes:
+    # 1. Service naming depends on num_channels:
+    #    Single-channel (num_channels: 1): /node_name/init, /node_name/target
+    #    Multi-channel (num_channels: 2): /joint_0/init, /joint_1/target, etc.
+    #
+    #    Examples for multi-channel:
+    #    ros2 service call /joint_0/target canopen_interfaces/srv/COTargetDouble "{target: 100.0}"
+    #    ros2 service call /joint_1/target canopen_interfaces/srv/COTargetDouble "{target: 50.0}"
+    #    ros2 service call /joint_0/init std_srvs/srv/Trigger
+    #    ros2 service call /joint_1/enable std_srvs/srv/Trigger
+    #
+    # 2. Joint state publishing:
+    #    Single-channel: name: ["node_name"]
+    #    Multi-channel: name: ["joint_0", "joint_1"]
+    #    Topic: ~/joint_states (sensor_msgs/msg/JointState)
+    #    - position: [pos_ch0, pos_ch1]
+    #    - velocity: [vel_ch0, vel_ch1]
+    #
+    # 3. Multi-channel services use channel_name as prefix:
+    #    - joint_0/init, joint_0/enable, joint_0/target, joint_0/position_mode, etc.
+    #    - joint_1/init, joint_1/enable, joint_1/target, joint_1/position_mode, etc.
+    #
+    # 4. Per-channel diagnostics are available with prefixes: ch0_, ch1_, etc.
+
+    # Example CiA 402-2 Object Dictionary mapping:
+    # Channel 0: Standard indices (0x6040, 0x6041, 0x6060, etc.)
+    # Channel 1: Offset +0x800 (0x6840, 0x6841, 0x6860, etc.)
+    # Channel 2: Offset +0x1000 (0x7040, 0x7041, 0x7060, etc.)
+
+
+    # SDO configuration for both channels
+    # Channel 0 (standard indices 0x6000-0x67FF)
+    # Channel 1 (offset indices 0x6800-0x6FFF)
+    sdo:
+      # Channel 0 configuration
+      - {index: 0x60C2, sub_index: 1, value: 50} # Set interpolation time for cyclic modes to 50 ms
+      - {index: 0x60C2, sub_index: 2, value: -3} # Set base 10-3s
+      - {index: 0x6081, sub_index: 0, value: 1000}
+      - {index: 0x6083, sub_index: 0, value: 2000}
+
+      # Channel 1 configuration (indices offset by 0x800)
+      - {index: 0x68C2, sub_index: 1, value: 50} # Set interpolation time for cyclic modes to 50 ms
+      - {index: 0x68C2, sub_index: 2, value: -3} # Set base 10-3s
+      - {index: 0x6881, sub_index: 0, value: 1000}
+      - {index: 0x6883, sub_index: 0, value: 2000}
+
+    # TPDO configuration for both channels
+    tpdo:
+      # Channel 0 TPDOs
+      1:
+        enabled: true
+        cob_id: "auto"
+        transmission: 0x01
+        mapping:
+          - {index: 0x6041, sub_index: 0} # status word channel 0
+          - {index: 0x6061, sub_index: 0} # mode of operation display channel 0
+      2:
+        enabled: true
+        cob_id: "auto"
+        transmission: 0x01
+        mapping:
+          - {index: 0x6064, sub_index: 0} # position actual value channel 0
+          - {index: 0x606c, sub_index: 0} # velocity actual value channel 0
+
+      # Channel 1 TPDOs (indices offset by 0x800)
+      3:
+        enabled: true
+        cob_id: "auto"
+        transmission: 0x01
+        mapping:
+          - {index: 0x6841, sub_index: 0} # status word channel 1
+          - {index: 0x6861, sub_index: 0} # mode of operation display channel 1
+      4:
+        enabled: true
+        cob_id: "auto"
+        transmission: 0x01
+        mapping:
+          - {index: 0x6864, sub_index: 0} # position actual value channel 1
+          - {index: 0x686c, sub_index: 0} # velocity actual value channel 1
+
+    # RPDO configuration for both channels
+    rpdo:
+      # Channel 0 RPDOs
+      1:
+        enabled: true
+        cob_id: "auto"
+        mapping:
+          - {index: 0x6040, sub_index: 0} # controlword channel 0
+          - {index: 0x6060, sub_index: 0} # mode of operation channel 0
+      2:
+        enabled: true
+        cob_id: "auto"
+        mapping:
+          - {index: 0x607A, sub_index: 0} # target position channel 0
+          - {index: 0x60FF, sub_index: 0} # target velocity channel 0
+
+      # Channel 1 RPDOs (indices offset by 0x800)
+      3:
+        enabled: true
+        cob_id: "auto"
+        mapping:
+          - {index: 0x6840, sub_index: 0} # controlword channel 1
+          - {index: 0x6860, sub_index: 0} # mode of operation channel 1
+      4:
+        enabled: true
+        cob_id: "auto"
+        mapping:
+          - {index: 0x687A, sub_index: 0} # target position channel 1
+          - {index: 0x68FF, sub_index: 0} # target velocity channel 1

--- a/canopen_tests/config/cia402_multichannel_system/ros2_controllers.yaml
+++ b/canopen_tests/config/cia402_multichannel_system/ros2_controllers.yaml
@@ -1,0 +1,54 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 10  # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    # Controller for channel 0
+    cia402_channel_0_controller:
+      type: canopen_ros2_controllers/Cia402DeviceController
+
+    # Controller for channel 1
+    cia402_channel_1_controller:
+      type: canopen_ros2_controllers/Cia402DeviceController
+
+    joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    forward_position_controller:
+      type: forward_command_controller/ForwardCommandController
+
+cia402_channel_0_controller:
+  ros__parameters:
+    joint: node_2_channel_0
+
+cia402_channel_1_controller:
+  ros__parameters:
+    joint: node_2_channel_1
+
+forward_position_controller:
+  ros__parameters:
+    joints:
+      - node_2_channel_0
+      - node_2_channel_1
+    interface_name: position
+
+joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - node_2_channel_0
+      - node_2_channel_1
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    state_publish_rate: 100.0
+    action_monitor_rate: 20.0
+    allow_partial_joints_goal: false
+    constraints:
+      stopped_velocity_tolerance: 0.2
+      goal_time: 0.0
+      node_2_channel_0: { trajectory: 0.2, goal: 0.1 }
+      node_2_channel_1: { trajectory: 0.2, goal: 0.1 }


### PR DESCRIPTION
This PR extends the canopen_402_driver to support multi-channel CANopen devices. This allows a single driver node to control multiple logical axes (sub-indices) residing on a single physical CANopen node ID (e.g., dual-channel motor controllers).

The implementation maintains full backward compatibility with existing single-channel configurations.

#### Changes:
- **Multi-axis Management:** Refactored the internal storage of motor objects to handle multiple instances of Motor402.
- **Per-Channel Services:** Services (e.g., init, halt, target) are now generated for each channel.
  - Single-channel (Legacy): Service names remain unchanged (e.g., ~/init).
  - Multi-channel: Services are namespaced by the channel name (e.g., ~/left_wheel/init, ~/right_wheel/target).
- **Configuration:**
  - Added `num_channels` parameter.
  - Added `channel_names` parameter for friendly service names.
   - Added `channels` list parameter to allow specific scaling and offsets per channel.
- **Joint States:** The JointState publisher now aggregates position, velocity, and effort data from all channels into a single message with corresponding names.
- **Diagnostics:** updated to report status for all active channels.

#### Configuration Example
New optional parameters in the node configuration section:

```yaml
num_channels: 2
channel_names: ["axis_1", "axis_2"]
channels:
  - scale_pos_to_dev: 1000.0
    offset_pos_to_dev: 0.0
  - scale_pos_to_dev: 2000.0
    offset_pos_to_dev: 10.0
```

#### Backward Compatibility
If num_channels is not specified or set to 1, the driver operates in legacy mode:
- Service names are not prefixed.
- Scaling factors are read from the root configuration
- JointState name default sot the node name

see https://github.com/ros-industrial/ros2_canopen/issues/80