### PR TITLE
CiA 402-2 multi-channel: support alternative Position Register

### DIFF
--- a/canopen_402_driver/include/canopen_402_driver/motor.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/motor.hpp
@@ -68,7 +68,9 @@ public:
     state_switch_timeout_(5),
     homing_timeout_seconds_(homing_timeout_seconds),
     channel_(channel),
-    effort_support_state_(-1)
+    effort_support_state_(-1),
+    speed_support_state_(-1),
+    position_support_idx_(-1)
   {
     this->driver = driver;
     // Calculate channel offset according to CiA 402-2: base_index + (channel * 0x800)
@@ -246,12 +248,59 @@ public:
   }
   double get_speed() const
   {
-    return (double)this->driver->universal_get_value<int32_t>(get_channel_index(0x606C), 0);
+    auto idx = get_channel_index(0x606C);
+    auto state = speed_support_state_.load();
+    if (state <= 0)
+    {
+      if (state == 0)
+      {
+        return 0.0;
+      }
+      bool has_object = this->driver->has_object(idx, 0);
+      speed_support_state_.store(has_object ? 1 : 0);
+      if (!has_object)
+      {
+        RCLCPP_WARN(
+          rclcpp::get_logger("canopen_402_driver"),
+          "speed interface disabled: object 0x%x:00 not found in EDS/OD.", idx);
+        return 0.0;
+      }
+    }
+    return (double)this->driver->universal_get_value<int16_t>(idx, 0);
   }
 
   double get_position() const
   {
-    return (double)this->driver->universal_get_value<int32_t>(get_channel_index(0x6064), 0);
+    auto idx = position_support_idx_.load();
+    if(0 == idx)
+    {
+      return 0.0;
+    }
+    else if(static_cast<uint16_t>(-1) == idx)
+    {
+      auto standard_idx = idx = get_channel_index(0x6064);
+      bool has_object = this->driver->has_object(idx, 0);
+      if(!has_object)
+      {
+         idx = get_channel_index(0x6063);
+         has_object = this->driver->has_object(idx, 0);
+         if(has_object)
+         {
+           RCLCPP_INFO(
+             rclcpp::get_logger("canopen_402_driver"),
+              "position interface: using object 0x%x:00.", idx);
+         }
+      }
+      position_support_idx_.store(has_object ? idx : 0);
+      if(!has_object)
+      {
+        RCLCPP_WARN(
+          rclcpp::get_logger("canopen_402_driver"),
+          "position interface disabled: object 0x%x:00 not found in EDS/OD.", standard_idx);
+        return 0.0;
+      }
+    }
+    return (double)this->driver->universal_get_value<int32_t>(idx, 0);
   }
 
   void set_diagnostic_status_msgs(std::shared_ptr<DiagnosticsCollector> status, bool enable)
@@ -310,6 +359,9 @@ private:
 
   // -1 unknown, 0 missing, 1 present
   mutable std::atomic<int> effort_support_state_;
+  mutable std::atomic<int> speed_support_state_;
+  // -1 unknown, 0 missing, otherwise index
+  mutable std::atomic<uint16_t> position_support_idx_;
 };
 
 }  // namespace ros2_canopen

--- a/canopen_402_driver/include/canopen_402_driver/motor.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/motor.hpp
@@ -272,27 +272,27 @@ public:
   double get_position() const
   {
     auto idx = position_support_idx_.load();
-    if(0 == idx)
+    if (0 == idx)
     {
       return 0.0;
     }
-    else if(static_cast<uint16_t>(-1) == idx)
+    else if (static_cast<uint16_t>(-1) == idx)
     {
       auto standard_idx = idx = get_channel_index(0x6064);
       bool has_object = this->driver->has_object(idx, 0);
-      if(!has_object)
+      if (!has_object)
       {
-         idx = get_channel_index(0x6063);
-         has_object = this->driver->has_object(idx, 0);
-         if(has_object)
-         {
-           RCLCPP_INFO(
-             rclcpp::get_logger("canopen_402_driver"),
-              "position interface: using object 0x%x:00.", idx);
-         }
+        idx = get_channel_index(0x6063);
+        has_object = this->driver->has_object(idx, 0);
+        if (has_object)
+        {
+          RCLCPP_INFO(
+            rclcpp::get_logger("canopen_402_driver"), "position interface: using object 0x%x:00.",
+            idx);
+        }
       }
       position_support_idx_.store(has_object ? idx : 0);
-      if(!has_object)
+      if (!has_object)
       {
         RCLCPP_WARN(
           rclcpp::get_logger("canopen_402_driver"),

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver.hpp
@@ -82,15 +82,6 @@ protected:
 
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr publish_joint_state;
 
-  // Global scale/offset (used as defaults)
-  double scale_pos_to_dev_;
-  double scale_pos_from_dev_;
-  double scale_vel_to_dev_;
-  double scale_vel_from_dev_;
-  double scale_eff_from_dev_;
-  double offset_pos_to_dev_;
-  double offset_pos_from_dev_;
-
   ros2_canopen::State402::InternalState switching_state_;
   int homing_timeout_seconds_;
 

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -408,8 +408,9 @@ void NodeCanopen402Driver<NODETYPE>::configure_common()
     "%f\nscale_vel_from_dev_ "
     "%f\nscale_eff_from_dev_ %f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ "
     "%f\nhoming_timeout_seconds_ %i\n",
-    num_channels_, scale_pos_to_dev_value, scale_pos_from_dev_value, scale_vel_to_dev_value, scale_vel_from_dev_value,
-    scale_eff_from_dev_value, offset_pos_to_dev_value, offset_pos_from_dev_value, homing_timeout_seconds_);
+    num_channels_, scale_pos_to_dev_value, scale_pos_from_dev_value, scale_vel_to_dev_value,
+    scale_vel_from_dev_value, scale_eff_from_dev_value, offset_pos_to_dev_value,
+    offset_pos_from_dev_value, homing_timeout_seconds_);
 
   // Create per-channel services
   create_per_channel_services();

--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -277,13 +277,13 @@ void NodeCanopen402Driver<NODETYPE>::configure_common()
   {
   }
 
-  scale_pos_to_dev_ = scale_pos_to_dev.value_or(1000.0);
-  scale_pos_from_dev_ = scale_pos_from_dev.value_or(0.001);
-  scale_vel_to_dev_ = scale_vel_to_dev.value_or(1000.0);
-  scale_vel_from_dev_ = scale_vel_from_dev.value_or(0.001);
-  scale_eff_from_dev_ = scale_eff_from_dev.value_or(0.001);
-  offset_pos_to_dev_ = offset_pos_to_dev.value_or(0.0);
-  offset_pos_from_dev_ = offset_pos_from_dev.value_or(0.0);
+  double scale_pos_to_dev_value = scale_pos_to_dev.value_or(1000.0);
+  double scale_pos_from_dev_value = scale_pos_from_dev.value_or(0.001);
+  double scale_vel_to_dev_value = scale_vel_to_dev.value_or(1000.0);
+  double scale_vel_from_dev_value = scale_vel_from_dev.value_or(0.001);
+  double scale_eff_from_dev_value = scale_eff_from_dev.value_or(0.001);
+  double offset_pos_to_dev_value = offset_pos_to_dev.value_or(0.0);
+  double offset_pos_from_dev_value = offset_pos_from_dev.value_or(0.0);
   switching_state_ = (ros2_canopen::State402::InternalState)switching_state.value_or(
     (int)ros2_canopen::State402::InternalState::Operation_Enable);
   homing_timeout_seconds_ = homing_timeout_seconds.value_or(10);
@@ -320,7 +320,7 @@ void NodeCanopen402Driver<NODETYPE>::configure_common()
   {
     for (uint8_t i = 0; i < num_channels_; ++i)
     {
-      channel_names_.push_back(std::string(this->node_->get_name()) + "/" + std::to_string(i));
+      channel_names_.push_back(std::string(this->node_->get_name()) + "/ch" + std::to_string(i));
     }
   }
 
@@ -329,13 +329,13 @@ void NodeCanopen402Driver<NODETYPE>::configure_common()
   channels_.resize(num_channels_);
   for (uint8_t i = 0; i < num_channels_; ++i)
   {
-    channels_[i].scale_pos_to_dev = scale_pos_to_dev_;
-    channels_[i].scale_pos_from_dev = scale_pos_from_dev_;
-    channels_[i].scale_vel_to_dev = scale_vel_to_dev_;
-    channels_[i].scale_vel_from_dev = scale_vel_from_dev_;
-    channels_[i].scale_eff_from_dev = scale_eff_from_dev_;
-    channels_[i].offset_pos_to_dev = offset_pos_to_dev_;
-    channels_[i].offset_pos_from_dev = offset_pos_from_dev_;
+    channels_[i].scale_pos_to_dev = scale_pos_to_dev_value;
+    channels_[i].scale_pos_from_dev = scale_pos_from_dev_value;
+    channels_[i].scale_vel_to_dev = scale_vel_to_dev_value;
+    channels_[i].scale_vel_from_dev = scale_vel_from_dev_value;
+    channels_[i].scale_eff_from_dev = scale_eff_from_dev_value;
+    channels_[i].offset_pos_to_dev = offset_pos_to_dev_value;
+    channels_[i].offset_pos_from_dev = offset_pos_from_dev_value;
   }
 
   try
@@ -408,8 +408,8 @@ void NodeCanopen402Driver<NODETYPE>::configure_common()
     "%f\nscale_vel_from_dev_ "
     "%f\nscale_eff_from_dev_ %f\noffset_pos_to_dev_ %f\noffset_pos_from_dev_ "
     "%f\nhoming_timeout_seconds_ %i\n",
-    num_channels_, scale_pos_to_dev_, scale_pos_from_dev_, scale_vel_to_dev_, scale_vel_from_dev_,
-    scale_eff_from_dev_, offset_pos_to_dev_, offset_pos_from_dev_, homing_timeout_seconds_);
+    num_channels_, scale_pos_to_dev_value, scale_pos_from_dev_value, scale_vel_to_dev_value, scale_vel_from_dev_value,
+    scale_eff_from_dev_value, offset_pos_to_dev_value, offset_pos_from_dev_value, homing_timeout_seconds_);
 
   // Create per-channel services
   create_per_channel_services();

--- a/canopen_402_driver/src/motor.cpp
+++ b/canopen_402_driver/src/motor.cpp
@@ -383,27 +383,29 @@ bool Motor402::handleInit()
   if (!m)
   {
     std::cout << "Homeing mode not supported" << std::endl;
-    return true;  // homing not supported
+     // homing not supported => switch MotorBase::No_Mode
   }
+  else
+  {
+    HomingMode * homing = dynamic_cast<HomingMode *>(m.get());
 
-  HomingMode * homing = dynamic_cast<HomingMode *>(m.get());
-
-  if (!homing)
-  {
-    std::cout << "Homing mode has incorrect handler" << std::endl;
-    return false;
-  }
-  RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Init: Switch to homing");
-  if (!switchMode(MotorBase::Homing))
-  {
-    std::cout << "Could not enter homing mode" << std::endl;
-    return false;
-  }
-  RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Init: Execute homing");
-  if (!homing->executeHoming())
-  {
-    std::cout << "Homing failed" << std::endl;
-    return false;
+    if (!homing)
+    {
+      std::cout << "Homing mode has incorrect handler" << std::endl;
+      return false;
+    }
+    RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Init: Switch to homing");
+    if (!switchMode(MotorBase::Homing))
+    {
+      std::cout << "Could not enter homing mode" << std::endl;
+      return false;
+    }
+    RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Init: Execute homing");
+    if (!homing->executeHoming())
+    {
+      std::cout << "Homing failed" << std::endl;
+      return false;
+    }
   }
   RCLCPP_INFO(rclcpp::get_logger("canopen_402_driver"), "Init: Switch no mode");
   if (!switchMode(MotorBase::No_Mode))

--- a/canopen_402_driver/src/motor.cpp
+++ b/canopen_402_driver/src/motor.cpp
@@ -383,7 +383,7 @@ bool Motor402::handleInit()
   if (!m)
   {
     std::cout << "Homeing mode not supported" << std::endl;
-     // homing not supported => switch MotorBase::No_Mode
+    // homing not supported => switch MotorBase::No_Mode
   }
   else
   {

--- a/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
+++ b/canopen_base_driver/include/canopen_base_driver/node_interfaces/node_canopen_base_driver_impl.hpp
@@ -240,7 +240,8 @@ template <class NODETYPE>
 void NodeCanopenBaseDriver<NODETYPE>::deactivate(bool called_from_base)
 {
   nmt_state_publisher_thread_.join();
-  if (poll_timer_) {
+  if (poll_timer_)
+  {
     poll_timer_->cancel();
   }
   emcy_queue_.reset();


### PR DESCRIPTION
This PR extends [Implement CiA 402-2 multi-channel support for multiple axes per CANopen node#404](https://github.com/ros-industrial/ros2_canopen/pull/404)
I'm with @mwopfner 's team.
We did some successful testing on our CiA 402 compliant compound hardware.
This PR proposes fixes for issues as described below:

 [ ] - fixed default channel names, must not contain digit only strings
 [ ] - removed duplicated scale/offset parameters already stored in ChannelContext
 [ ] - if homing not supported, explicitly switch to MotorBase::No_Mode in Motor402::handleInit()
 [ ] - made speed interface in PDO 0x606C optional
 [ ] - made position interface in PDO 0x6064 optional, if missing try position provided in optional PDO 0x6063  

The CiA 402 compliant features of the hardware relevant to this PR are: 

- only supported mode is Velocity Mode,  which refers to the implementation's MotorBase::Velocity  (2)
 [ ] -   therefore no speed interface in PDO 0x606C
 [ ] -   therefore no position interface in PDO 0x6064, instead position provided in PDO 0x6063 can be used
- no homing mode supported 

If channel_names parameter omitted from bus.yml,
the driver set default channel names to digit only strings,
resulting in the following error messages:
```
[ros2_control_node-1] terminate called after throwing an instance of 'rclcpp::exceptions::InvalidServiceNameError'
[ros2_control_node-1]   what():  Invalid service name: topic name token must not start with a number:
[ros2_control_node-1]   'power_board_1/0/init'

```