### PR TITLE
Configuring CiA 402 arbitrary multiple axes

### DIFF
--- a/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/node_interfaces/node_canopen_402_driver_impl.hpp
@@ -514,8 +514,13 @@ void NodeCanopen402Driver<NODETYPE>::add_to_master()
   channels_.resize(num_channels_);
   for (uint8_t ch = 0; ch < num_channels_; ++ch)
   {
+    uint8_t idx = (0 == ch) ? 4 : ch;
+    RCLCPP_INFO(
+            this->node_->get_logger(),
+             "add_to_master() ch %u idx %u"
+             , ch, idx );
     channels_[ch].motor =
-      std::make_shared<Motor402>(this->lely_driver_, switching_state_, homing_timeout_seconds_, ch);
+      std::make_shared<Motor402>(this->lely_driver_, switching_state_, homing_timeout_seconds_, idx);
   }
 }
 


### PR DESCRIPTION
This PR is intended to discuss additional configuration of [ Implement CiA 402-2 multi-channel support for multiple axes per CANopen node#404](https://github.com/ros-industrial/ros2_canopen/pull/404 )
I'm with @mwopfner 's team.
We did testing on our CiA 402 compliant multi-axle, compound hardware:
we could operate multiple axles successfully, but needed a workaround and support of arbitrary axle numbers.

The current driver implementation allocates channels 0..num_channels-1 and assigns these channels to axle 0..num_channels-1, respectively.
But our tests showed the need of arbitrary axle numbers support.

- [ ] Therefore we propose additional parameters 'axle' in the node configuration section defining the corresponding axle number.

```
num_channels: 2
channel_names: ["axis_1", "axis_2"]
channels:
  - scale_pos_to_dev: 1000.0
    offset_pos_to_dev: 0.0
    axle: 1
  - scale_pos_to_dev: 2000.0
    offset_pos_to_dev: 10.0
    axle: 2
```
axle is either not set at all (values assigned automatically) or set for each channel to a unique number, respectively.
valid axle numbers are integers in the range 0..7.
The driver operates in legacy mode if axle not specified and num_channels set to 1 or not specified.

- [ ] We also would consider it beneficial if arbitrary channel numbers were supported, i. e. channel m always referred to axle m.

Please crosscheck if this approach would be feasible.

Hardware Design
Our hardware provides configurable power supplies and multiple motors with different capabilities:  
- axles 1, 2, 3, and 4 i. e. object ranges 0x6800 ff., 0x7000 ff., 0x7800 ff., and 0x8000 ff., respectively
- CiA 401 conforming I/O module in object range 0x6000 ff., therefore axle 0 not realized

This is compliant with the standards as CiA 402 (see section 5.3 The object dictionary) allows up to 8 axles, 0..7, and multi axles devices may realize any combination thereof.
Optionally, any axle can be replaced by an I/O module conforming CiA 401.  

Hint: our framework accesses axle 1 as channel 1, and axle 2 as channel 2, but no other channels or axles.  The driver automatically allocates also channel 0. As a workaround we patched the driver, and assigned channel 0 an existing, but not used axle 4.  This was possible only because EDS file happend to provide additional axles 3 and 4,  preventing the driver from issuing an error.