### PR TITLE
Fix -Wreorder gcc warning

### DIFF
--- a/canopen_402_driver/include/canopen_402_driver/default_homing_mode.hpp
+++ b/canopen_402_driver/include/canopen_402_driver/default_homing_mode.hpp
@@ -55,7 +55,7 @@ public:
   DefaultHomingMode(
     std::shared_ptr<LelyDriverBridge> driver, int homing_timeout_seconds,
     uint16_t channel_offset = 0)
-  : homing_timeout_seconds_(homing_timeout_seconds), channel_offset_(channel_offset)
+  : channel_offset_(channel_offset), homing_timeout_seconds_(homing_timeout_seconds)
   {
     this->driver = driver;
   }


### PR DESCRIPTION
Match the member initializer list in DefaultHomingMode constructor to declaration order. Otherwise, gcc emits a warning with -Wreorder.