### PR TITLE
Fix out-of-bounds read of msef in Ros2ControlEmcyData::set_emcy

### DIFF
--- a/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/canopen_system.hpp
@@ -252,16 +252,16 @@ struct Ros2ControlEmcyData
     std::memcpy(&er_data, &e.er, sizeof(uint8_t));
     error_register = static_cast<double>(er_data);
 
-    uint16_t msef_data;
-    std::memcpy(&msef_data, &e.msef[0], sizeof(uint16_t));
+    uint8_t msef_data;
+    std::memcpy(&msef_data, &e.msef[0], sizeof(uint8_t));
     manufacturer_error_code1 = static_cast<double>(msef_data);
-    std::memcpy(&msef_data, &e.msef[1], sizeof(uint16_t));
+    std::memcpy(&msef_data, &e.msef[1], sizeof(uint8_t));
     manufacturer_error_code2 = static_cast<double>(msef_data);
-    std::memcpy(&msef_data, &e.msef[2], sizeof(uint16_t));
+    std::memcpy(&msef_data, &e.msef[2], sizeof(uint8_t));
     manufacturer_error_code3 = static_cast<double>(msef_data);
-    std::memcpy(&msef_data, &e.msef[3], sizeof(uint16_t));
+    std::memcpy(&msef_data, &e.msef[3], sizeof(uint8_t));
     manufacturer_error_code4 = static_cast<double>(msef_data);
-    std::memcpy(&msef_data, &e.msef[4], sizeof(uint16_t));
+    std::memcpy(&msef_data, &e.msef[4], sizeof(uint8_t));
     manufacturer_error_code5 = static_cast<double>(msef_data);
   }
 


### PR DESCRIPTION
COEmcy::msef is uint8_t[5]. The previous memcpy used a uint16_t destination and sizeof(uint16_t) per byte, which read 2 bytes per manufacturer error code (overlapping with the next byte) and read one byte past the end of the array on the last iteration (-Wstringop-overread). Use uint8_t and sizeof(uint8_t) so each error code corresponds to exactly one msef byte, matching the CiA 301 EMCY layout.