### PR TITLE
canopen_ros2_control: honor channel for RobotSystem multi-axis devices

### DIFF
--- a/canopen_ros2_control/include/canopen_ros2_control/cia402_data.hpp
+++ b/canopen_ros2_control/include/canopen_ros2_control/cia402_data.hpp
@@ -66,8 +66,20 @@ struct Cia402Data
 
     node_id = config["node_id"].as<uint16_t>();
 
-    // Get channel parameter (defaults to 0 for backward compatibility)
-    if (config["channel"])
+    // Get channel parameter (defaults to 0 for backward compatibility).
+    // URDF joint <param name="channel"> takes precedence so that RobotSystem
+    // can map multiple joints onto a single multi-channel CANopen node — the
+    // same convention Cia402System already uses (see cia402_system.cpp).
+    auto joint_channel_param = joint.parameters.find("channel");
+    if (joint_channel_param != joint.parameters.end())
+    {
+      channel = static_cast<uint8_t>(std::stoi(joint_channel_param->second));
+      RCLCPP_INFO(
+        rclcpp::get_logger(joint_name),
+        "Node id for '%s' is '%u', channel is '%u' (from URDF joint param)",
+        joint.name.c_str(), node_id, channel);
+    }
+    else if (config["channel"])
     {
       channel = config["channel"].as<uint8_t>();
       RCLCPP_INFO(
@@ -160,14 +172,14 @@ struct Cia402Data
 
   void read_state()
   {
-    actual_position = driver->get_position();
-    actual_velocity = driver->get_speed();
-    actual_effort = driver->get_effort();
+    actual_position = driver->get_position(channel);
+    actual_velocity = driver->get_speed(channel);
+    actual_effort = driver->get_effort(channel);
   }
 
   void write_target()
   {
-    const uint16_t & mode = driver->get_mode();
+    const uint16_t & mode = driver->get_mode(channel);
     switch (mode)
     {
       case MotorBase::No_Mode:
@@ -175,15 +187,15 @@ struct Cia402Data
       case MotorBase::Profiled_Position:
       case MotorBase::Cyclic_Synchronous_Position:
       case MotorBase::Interpolated_Position:
-        driver->set_target(target_position);
+        driver->set_target(target_position, channel);
         break;
       case MotorBase::Profiled_Velocity:
       case MotorBase::Cyclic_Synchronous_Velocity:
-        driver->set_target(target_velocity);
+        driver->set_target(target_velocity, channel);
         break;
       case MotorBase::Profiled_Torque:
       case MotorBase::Cyclic_Synchronous_Torque:
-        driver->set_target(target_torque);
+        driver->set_target(target_torque, channel);
         break;
       default:
         RCLCPP_INFO(rclcpp::get_logger("robot_system_interface"), "Mode not supported");
@@ -212,7 +224,7 @@ struct Cia402Data
       rclcpp::get_logger(joint_name),
       "Switching to '%s' command mode with CIA402 operation mode '%u'",
       interfaces_to_running[0].c_str(), mode);
-    return driver->set_operation_mode(mode);
+    return driver->set_operation_mode(mode, channel);
   }
 
   bool check_id(uint8_t id)

--- a/canopen_ros2_control/src/robot_system.cpp
+++ b/canopen_ros2_control/src/robot_system.cpp
@@ -139,7 +139,7 @@ hardware_interface::CallbackReturn RobotSystem::on_activate(
 {
   for (auto & data : robot_motor_data_)
   {
-    if (!data.driver->init_motor())
+    if (!data.driver->init_motor(data.channel))
     {
       RCLCPP_ERROR(robot_system_logger, "Failed to activate '%s'", data.joint_name.c_str());
       return CallbackReturn::FAILURE;
@@ -152,7 +152,7 @@ hardware_interface::CallbackReturn RobotSystem::on_deactivate(
 {
   for (auto & data : robot_motor_data_)
   {
-    if (!data.driver->halt_motor())
+    if (!data.driver->halt_motor(data.channel))
     {
       RCLCPP_ERROR(robot_system_logger, "Failed to deactivate '%s'", data.joint_name.c_str());
       return CallbackReturn::FAILURE;


### PR DESCRIPTION
PR #404 added CiA 402-2 multi-channel support to canopen_402_driver, and Cia402System reads `channel` from URDF joint parameters. However, RobotSystem forwarded only the bus.yml device dump to Cia402Data::init_data, which does not surface a per-channel `channel` key — so every joint fell back to channel 0 and the read/write/activate loops also ignored the channel.

This patch makes RobotSystem behave like Cia402System for the channel parameter:

* Cia402Data::init_data prefers `<param name="channel">` from the URDF joint over the (rarely populated) bus.yml `channel` entry. The bus.yml branch is kept for backward compatibility.
* read_state, write_target and perform_switch pass `channel` into the driver helpers (get_position/get_speed/get_effort/get_mode/set_target/ set_operation_mode), which already accept a channel argument with a default of 0.
* RobotSystem::on_activate/on_deactivate forward data.channel to init_motor/halt_motor.

Backward compatible: joints without a `channel` URDF parameter keep using channel 0 exactly as before.